### PR TITLE
Fixes

### DIFF
--- a/src/components/Drawer/styles.ts
+++ b/src/components/Drawer/styles.ts
@@ -7,7 +7,7 @@ export const drawerContainer = (width: string): SerializedStyles => {
     left: 0;
     height: 100%;
     width: 100%;
-    z-index: 1000;
+    z-index: 1002; //openit: was 1000
 
     .dialog {
       position: absolute;

--- a/src/components/FormElements/DateInput/styles.ts
+++ b/src/components/FormElements/DateInput/styles.ts
@@ -19,4 +19,9 @@ export const dateInput = (
   .react-datepicker-wrapper {
     width: 100%;
   }
+  
+  //openit
+  .react-datepicker-popper {
+    z-index: 2;
+  }
 `;

--- a/src/components/FormElements/MultiSelect/MultiSelect.tsx
+++ b/src/components/FormElements/MultiSelect/MultiSelect.tsx
@@ -12,6 +12,7 @@ import { CaretDownSVG, DropUpArrowSVG } from "@icons/core";
 export type MultiSelectProps = {
   placeholder: string;
   id: string;
+  status?: "valid" | "error"; //openit
   size?: InputSize;
   label?: string;
   inline?: boolean;
@@ -25,6 +26,7 @@ export type MultiSelectProps = {
 const MultiSelect: FC<MultiSelectProps> = (props) => {
   const {
     placeholder,
+    status = "valid", //openit
     size = "md",
     id,
     options,
@@ -36,6 +38,8 @@ const MultiSelect: FC<MultiSelectProps> = (props) => {
   } = props;
   const hasLabel = Boolean(label);
   const containerClassNames = classNames({
+    valid: status === "valid", //openit
+    error: status === "error", //openit
     inline: hasLabel && inline,
     [className ?? ""]: className,
   });
@@ -63,7 +67,8 @@ const MultiSelect: FC<MultiSelectProps> = (props) => {
           case useSelect.stateChangeTypes.MenuKeyDownSpaceButton:
           case useSelect.stateChangeTypes.ItemClick:
             if (itemInItems && changes.selectedItem) {
-              removeSelectedItem(changes.selectedItem);
+              //removeSelectedItem(changes.selectedItem); //old buggy way
+              removeSelectedItem(itemInItems); //openit: use itemInItems instead of changes.selectedItem (else initial vals cannot be unchecked)
             } else if (changes.selectedItem) {
               addSelectedItem(changes.selectedItem);
             }
@@ -77,6 +82,14 @@ const MultiSelect: FC<MultiSelectProps> = (props) => {
       },
     });
 
+  //openit: show all 'selected' items when collapsed
+  const _items =
+    <div>
+      {selectedItems.map((item, index) => {
+        return <span key={index} style={{ border: "1px solid #aaa", background: "#eee", marginRight: "5px" }}>{(item as CheckboxOption).label}</span>
+      })}
+    </div>;
+
   return (
     <div
       css={(theme): SerializedStyles => multiSelectContainer(theme, { isOpen, size, inline })}
@@ -84,13 +97,15 @@ const MultiSelect: FC<MultiSelectProps> = (props) => {
     >
       {hasLabel && <Label {...getLabelProps({ id })}>{label}</Label>}
       <button type="button" className="select-btn" {...getToggleButtonProps(getDropdownProps())}>
-        {(selectedItems.length && (selectedItems[0] as CheckboxOption).label) || placeholder}
+        {/* {(selectedItems.length && (selectedItems[0] as CheckboxOption).label) || placeholder} */}
+        {(selectedItems.length && _items) || placeholder}
         <CaretDownSVG height="24" />
       </button>
       <ul data-testid="list-container" {...getMenuProps()}>
         <div className="content">
           <Text fontSize="sm"> Select one or more items</Text>
-          <button className="close-btn" data-testid="close-btn" onClick={(): void => closeMenu()}>
+          {/* openit: added type="button", otherwise would act as 'form submit' */}
+          <button type="button" className="close-btn" data-testid="close-btn" onClick={(): void => closeMenu()}>
             <DropUpArrowSVG height={20} />
           </button>
         </div>
@@ -104,6 +119,7 @@ const MultiSelect: FC<MultiSelectProps> = (props) => {
                 id={`${option.value}`}
                 size={size}
                 checked={Boolean(isSelected)}
+                onChange={() => { }} //openit: for warning about 'checked' without onChange
                 inline
                 containerClassName="checkbox"
                 {...option}

--- a/src/components/FormElements/MultiSelect/styles.ts
+++ b/src/components/FormElements/MultiSelect/styles.ts
@@ -12,6 +12,14 @@ export const multiSelectContainer = (
   { isOpen, size, inline }: { isOpen: boolean; size: InputSize; inline: boolean },
 ): SerializedStyles => css`
   ${inputContainerBaseStyles({ block: true })}
+
+  //openit
+  &.error {
+    .select-btn {
+      border-color: ${formElements.input.errorColor};
+    }
+  }
+
   position: relative;
 
   ul {
@@ -27,7 +35,7 @@ export const multiSelectContainer = (
     border: 1px solid ${formElements.input.inputBorderColor};
     border-radius: 5px;
     margin: 0;
-    z-index: 1;
+    z-index: 4; //openit: was 1 -> 4 because Checkbox has 3
 
     .checkbox {
       padding: 0 0 0 ${inline ? "1rem" : "0.5rem"};

--- a/src/components/FormElements/Select/Select.tsx
+++ b/src/components/FormElements/Select/Select.tsx
@@ -9,6 +9,7 @@ import { ExtendableProps } from "types/common";
 export type SelectProps = ExtendableProps<
   SelectHTMLAttributes<HTMLSelectElement>,
   {
+    status?: "valid" | "error"; //openit
     size?: "md" | "lg";
     label?: string;
     inline?: boolean;
@@ -19,6 +20,7 @@ export type SelectProps = ExtendableProps<
 const Select: ForwardRefRenderFunction<HTMLSelectElement, SelectProps> = (props, forwardedRef) => {
   const {
     id,
+    status = "valid", //openit
     size = "md",
     label,
     inline = false,
@@ -29,6 +31,8 @@ const Select: ForwardRefRenderFunction<HTMLSelectElement, SelectProps> = (props,
   } = props;
   const hasLabel = Boolean(label);
   const containerClassNames = classNames({
+    valid: status === "valid", //openit
+    error: status === "error", //openit
     inline: hasLabel && inline,
     [className]: className,
   });

--- a/src/components/FormElements/Select/styles.ts
+++ b/src/components/FormElements/Select/styles.ts
@@ -8,6 +8,13 @@ export const selectContainer = (
 ): SerializedStyles => css`
   ${inputContainerBaseStyles({ block: true })}
 
+  //openit
+  &.error {
+    .select-input-wrapper select {
+      border-color: ${formElements.input.errorColor};
+    }
+  }
+
   label {
     margin: 0 0 0.5rem 0.5rem;
   }

--- a/src/components/Sidebar/styles.ts
+++ b/src/components/Sidebar/styles.ts
@@ -1,6 +1,8 @@
 import { css, SerializedStyles, Theme } from "@emotion/react";
 
 export const mainNavContainer = ({ sidebar }: Theme): SerializedStyles => css`
+  overflow: auto; //openit: scroll if many items
+
   position: sticky;
   top: 0;
   display: flex;


### PR DESCRIPTION
1) Sidebar/styles.ts: overflow: auto; -> scroll if many items
2) Drawer/styles.ts: z-index: 1002; (was 1000 and SideBar has 1001) -> Used to appear under SideBar
3) MultiSelect/styles.ts: z-index: 4; (was 1 -> 4 because Checkbox has 3) -> if there was <Input> right below of MultiSelect, the dropdown was hidding behind
4) MultiSelect: Add type="button" to 'close-bth' -> By default it behaves as submit.
5) MultiSelect: Was showing only one of selected -> simple impl to show all
6) MultiSelect: Added support for State (valid | error) like Input
7) Select: Added support for State (valid | error) like Input
8) DateInput/styles.ts: Added extra style -> if there was <Input> right below of DateInput, the popper was hidding behind
 .react-datepicker-popper {
  z-index: 2;
 }