### PR TITLE
Fixes for v2.1.7

### DIFF
--- a/src/components/FormElements/RadioGroup/RadioGroup.tsx
+++ b/src/components/FormElements/RadioGroup/RadioGroup.tsx
@@ -30,7 +30,7 @@ const RadioGroup: FC<RadioGroupProps> = ({
   useEffect(() => {
     setSelectedValue(initialValue);
   }, [initialValue]);
-  
+
   useEffect(() => {
     onChange && onChange(selectedValue);
   }, [selectedValue, onChange]);

--- a/src/components/FormElements/RadioGroup/RadioGroup.tsx
+++ b/src/components/FormElements/RadioGroup/RadioGroup.tsx
@@ -26,6 +26,11 @@ const RadioGroup: FC<RadioGroupProps> = ({
     setSelectedValue(e.target.value);
   };
 
+  //fix
+  useEffect(() => {
+    setSelectedValue(initialValue);
+  }, [initialValue]);
+  
   useEffect(() => {
     onChange && onChange(selectedValue);
   }, [selectedValue, onChange]);

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -70,7 +70,7 @@ const Modal: FC<ReactModalProps> & ModalCompoundProps = ({
   size = "md",
   rootElementSelector = "#app",
   closeOnOutsideClick = true, //fix
-  style = {} //fix
+  style = {}, //fix
 }) => {
   const rootElement = document.querySelector(rootElementSelector) as HTMLElement;
   const clonedChildren = Children.map(children, (child) =>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -59,6 +59,8 @@ export type ReactModalProps = Pick<Props, "isOpen"> & {
   onClose?: () => void;
   size?: Size;
   rootElementSelector?: string;
+  closeOnOutsideClick?: boolean; //fix
+  style?: ReactModal.Styles; //fix
 };
 
 const Modal: FC<ReactModalProps> & ModalCompoundProps = ({
@@ -67,6 +69,8 @@ const Modal: FC<ReactModalProps> & ModalCompoundProps = ({
   onClose = () => void 0,
   size = "md",
   rootElementSelector = "#app",
+  closeOnOutsideClick = true, //fix
+  style = {} //fix
 }) => {
   const rootElement = document.querySelector(rootElementSelector) as HTMLElement;
   const clonedChildren = Children.map(children, (child) =>
@@ -96,6 +100,8 @@ const Modal: FC<ReactModalProps> & ModalCompoundProps = ({
           closeTimeoutMS={200}
           portalClassName={css(portalStyles(size))}
           ariaHideApp={false}
+          shouldCloseOnOverlayClick={closeOnOutsideClick} //fix
+          style={style} //fix
         >
           {clonedChildren}
         </ReactModal>

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, ReactElement, Children } from "react";
+import React, { FC, useState, useEffect, ReactElement, Children } from "react";
 import { SerializedStyles } from "@emotion/react";
 import Select from "../FormElements/Select/Select";
 import TabsNavItem from "./TabsNavItem";
@@ -9,7 +9,7 @@ type TabsProps = React.HTMLAttributes<HTMLElement> & {
   stickyHeader?: boolean;
   responsiveHeader?: boolean;
   initialTab?: number; //fix
-  onTabSelected?: (index: number) => void //fix
+  onTabSelected?: (index: number) => void; //fix
 };
 
 type TabPaneProps = {
@@ -48,16 +48,14 @@ const Tabs: FC<TabsProps> & TabsCompoundProps = ({
     setActiveTab(index);
 
     //fix
-    if (onTabSelected)
-      onTabSelected(index);
+    if (onTabSelected) onTabSelected(index);
   };
   const displayResponsiveHeader = tabTitles?.length && responsiveHeader;
 
   //fix
-  React.useEffect(() => {
-    if (initialTab == activeTab || initialTab < 0)
-      return;
-    
+  useEffect(() => {
+    if (initialTab == activeTab || initialTab < 0) return;
+
     setActiveTab(initialTab);
   }, [initialTab]);
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -8,6 +8,8 @@ import { container, tabsHeader } from "./styles";
 type TabsProps = React.HTMLAttributes<HTMLElement> & {
   stickyHeader?: boolean;
   responsiveHeader?: boolean;
+  initialTab?: number; //fix
+  onTabSelected?: (index: number) => void //fix
 };
 
 type TabPaneProps = {
@@ -25,6 +27,8 @@ const Tabs: FC<TabsProps> & TabsCompoundProps = ({
   children,
   stickyHeader = false,
   responsiveHeader = false,
+  initialTab = 0, //fix
+  onTabSelected, //fix
   ...rest
 }) => {
   const [activeTab, setActiveTab] = useState(0);
@@ -42,8 +46,20 @@ const Tabs: FC<TabsProps> & TabsCompoundProps = ({
   }));
   const onSelectTab = (index: number): void => {
     setActiveTab(index);
+
+    //fix
+    if (onTabSelected)
+      onTabSelected(index);
   };
   const displayResponsiveHeader = tabTitles?.length && responsiveHeader;
+
+  //fix
+  React.useEffect(() => {
+    if (initialTab == activeTab || initialTab < 0)
+      return;
+    
+    setActiveTab(initialTab);
+  }, [initialTab]);
 
   return (
     <section css={container} {...rest}>


### PR DESCRIPTION
## Description

Additions and fixes for components: Modal, Tabs and RadioGroup

## Changes

This PR affects the Modal, Tabs and RadioGroup components

## Fixes

Modal: added the optional props: closeOnOutsideClick and style
Tabs: added the optional callback 'onTabSelected' (for allowing the 'parent' component to handle tab changes) and also the optional prop for setting the initially active tab.
RadioGroup: fixes the issue of not re-rendering the component, when initial value changes.
