### PR TITLE
Fixes

### DIFF
--- a/src/components/FormElements/RadioGroup/RadioGroup.tsx
+++ b/src/components/FormElements/RadioGroup/RadioGroup.tsx
@@ -30,7 +30,7 @@ const RadioGroup: FC<RadioGroupProps> = ({
   useEffect(() => {
     setSelectedValue(initialValue);
   }, [initialValue]);
-  
+
   useEffect(() => {
     onChange && onChange(selectedValue);
   }, [selectedValue, onChange]);

--- a/src/components/FormElements/RadioGroup/RadioGroup.tsx
+++ b/src/components/FormElements/RadioGroup/RadioGroup.tsx
@@ -26,6 +26,11 @@ const RadioGroup: FC<RadioGroupProps> = ({
     setSelectedValue(e.target.value);
   };
 
+  //fix
+  useEffect(() => {
+    setSelectedValue(initialValue);
+  }, [initialValue]);
+  
   useEffect(() => {
     onChange && onChange(selectedValue);
   }, [selectedValue, onChange]);

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -66,8 +66,10 @@ const Tabs: FC<TabsProps> & TabsCompoundProps = ({
 
   const handLeftArrowClick = () => {
     if (activeTab > 0) {
-      scrollToTab(activeTab - 1);
-      setActiveTab((currentTab) => currentTab - 1);
+      //scrollToTab(activeTab - 1);
+      //setActiveTab((currentTab) => currentTab - 1);
+
+      onSelectTab(activeTab - 1); //fix: fully simulate 'click'
     }
   };
 
@@ -79,8 +81,10 @@ const Tabs: FC<TabsProps> & TabsCompoundProps = ({
 
   const handRightArrowClick = () => {
     if (tabTitles && activeTab < tabTitles.length - 1) {
-      scrollToTab(activeTab + 1);
-      setActiveTab((currentTab) => currentTab + 1);
+      //scrollToTab(activeTab + 1);
+      //setActiveTab((currentTab) => currentTab + 1);
+
+      onSelectTab(activeTab + 1); //fix: fully simulate 'click'
     }
   };
 
@@ -96,6 +100,7 @@ const Tabs: FC<TabsProps> & TabsCompoundProps = ({
         newSelectedTab = tabTitles.length - 1;
       }
 
+      scrollToTab(newSelectedTab); //fix
       setActiveTab(newSelectedTab);
     }
   }, [selectedTab]);


### PR DESCRIPTION
## Description

This PR affects Tab and the RadioGroup components

## Changes

This PR affects Tab and the RadioGroup components

## Fixes

This PR resolves a Tab issue of fully simulate 'tab click' on right or left arrow click and also applies scrollToTab when selectedTab changes. Also it resolves a RadioGroup issue when the initialValue changes.
