### PR TITLE
fix(tabs component): revert previous functionality of scrolling in tabs

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -23,8 +23,12 @@ type TabsCompoundProps = {
   TabPane: FC<TabPaneProps>;
 };
 
+//TODO: find a way to perform scrolling to tab
 const scrollToTab = (tabIndex: number) => {
-  document.querySelector(`#tab-${tabIndex}`)?.scrollIntoView();
+  const tabOffset = document.querySelector(`#tab-${tabIndex}`)?.getBoundingClientRect().x;
+
+  const tablist = document.getElementsByTagName("nav")[0];
+  tabOffset && tablist.scrollTo(tabOffset > 0 ? tabOffset - 16 : 0, 0);
 };
 
 const Tabs: FC<TabsProps> & TabsCompoundProps = ({


### PR DESCRIPTION
## Description
Due to RTL implementation tabs were scrolling into view. This pr reverts this functionality
