### PR TITLE
fix(modal.tsx): do not render close button when onClose is undefined

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -170,3 +170,18 @@ export const ModalWithCustomStyles: Story<ReactModalProps> = (args) => {
     </div>
   );
 };
+
+export const ModalWithNoCloseButton: Story<ReactModalProps> = (args) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div>
+      <Button onClick={(): void => setIsOpen(true)}>Modal without close button</Button>
+      <Modal {...args} isOpen={isOpen}>
+        <Modal.Header>This is the modal title</Modal.Header>
+        <Modal.Body>This is the modal body</Modal.Body>
+        <Modal.Footer>This is the modal footer</Modal.Footer>
+      </Modal>
+    </div>
+  );
+};

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -78,6 +78,19 @@ describe("<Modal>", () => {
     expect(mockedOnClose).toHaveBeenCalledTimes(1);
   });
 
+  it("Header renders correctly without close btn", () => {
+    const { headerTxt } = getModalProps();
+
+    render(
+      <Modal isOpen>
+        <Modal.Header>{headerTxt}</Modal.Header>
+      </Modal>,
+    );
+    const closeBtn = screen.queryByTestId("header-close-button");
+
+    expect(closeBtn).not.toBeInTheDocument();
+  });
+
   it("Header renders correctly with JSX content", () => {
     const { headerTxt } = getModalProps();
     render(

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -15,7 +15,13 @@ const Header: FC<HeaderProps> = ({ children, onClose }) => {
     <header css={modalHeader} data-testid="modal-header">
       <div>{title}</div>
       {onClose && (
-        <a role="button" className="close-btn" aria-label="Close button" onClick={onClose}>
+        <a
+          role="button"
+          className="close-btn"
+          aria-label="Close button"
+          data-testid="header-close-button"
+          onClick={onClose}
+        >
           <CloseCircledSVG height={28} />
         </a>
       )}
@@ -66,7 +72,7 @@ export type ReactModalProps = Pick<Props, "isOpen"> & {
 const Modal: FC<ReactModalProps> & ModalCompoundProps = ({
   children,
   isOpen,
-  onClose = () => void 0,
+  onClose,
   size = "md",
   rootElementSelector = "#app",
   closeOnOutsideClick = true,

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -19,15 +19,6 @@ exports[`<Modal> matches snapshot 1`] = `
         Test header
       </h2>
     </div>
-    <a
-      aria-label="Close button"
-      class="close-btn"
-      role="button"
-    >
-      <svg-file-stub
-        height="28"
-      />
-    </a>
   </header>
   <article
     class="css-18mo2pj-modalContent"
@@ -63,15 +54,6 @@ exports[`<Modal> matches snapshot with all props 1`] = `
         Test header
       </h2>
     </div>
-    <a
-      aria-label="Close button"
-      class="close-btn"
-      role="button"
-    >
-      <svg-file-stub
-        height="28"
-      />
-    </a>
   </header>
   <article
     class="css-18mo2pj-modalContent"
@@ -134,15 +116,6 @@ exports[`<Modal> matches snapshot with cutom HTML classes 1`] = `
         Test header
       </h2>
     </div>
-    <a
-      aria-label="Close button"
-      class="close-btn"
-      role="button"
-    >
-      <svg-file-stub
-        height="28"
-      />
-    </a>
   </header>
   <article
     class="css-18mo2pj-modalContent"


### PR DESCRIPTION
## Description

When onClose function is undefined, then do not render the close button

## Changes

This PR affects the Modal component
A new story added for Modal with no close button
A new test written for Modal with no close button


