### PR TITLE
fix(table): display tooltip in overflow columns

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -50,3 +50,6 @@ export const Default = Template.bind({});
 
 export const WithTooManyPages = Template.bind({});
 WithTooManyPages.args = { totalPages: 1000 };
+
+export const WithZeroPages = Template.bind({});
+WithZeroPages.args = { totalPages: 0 };

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -29,8 +29,7 @@ const Pagination: FC<PaginationProps> = ({
   const [selectedListItem, setSelectedListItem] = useState<number>(pageSize);
   const isRtl = dir === "rtl";
   const isPrevBtnDisabled = page === 1;
-  const isNextBtnDisabled = page === totalPages;
-
+  const isNextBtnDisabled = page === totalPages || totalPages === 0;
   useClickOutside(wrapperRef, () => setIsListOpen(false));
 
   const toggleList = (): void => {

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -24,20 +24,34 @@ export default {
   args: {
     columns: [
       { accessor: "id", cell: "Code", classNames: ["id"] },
-      { accessor: "description", cell: "Description", classNames: ["description"] },
-      { accessor: "name", cell: "Name", classNames: ["name"] },
+      { accessor: "description", cell: "Description", classNames: ["description"], maxWidth: 100 },
+      { accessor: "name", cell: "Name", classNames: ["name"], maxWidth: 100 },
       { accessor: "category", cell: "Category", classNames: ["category"] },
     ],
     rows: [
       {
         id: 271,
-        description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. ",
+        description: (
+          <div className="has-overflow">
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+          </div>
+        ),
         name: "Test",
         category: "Test",
         code: "Test",
       },
       { id: 272, description: "Test", name: "Test", category: "Test", code: "Test" },
-      { id: 273, description: "Test", name: "Test", category: "Test", code: "Test" },
+      {
+        id: 273,
+        description: "Test",
+        name: (
+          <div className="has-overflow">
+            Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+          </div>
+        ),
+        category: "Test",
+        code: "Test",
+      },
       { id: 274, description: "Test", name: "Test", category: "Test", code: "Test" },
     ],
     emptyState: {

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -24,26 +24,14 @@ export default {
   args: {
     columns: [
       { accessor: "id", cell: "Code", classNames: ["id"] },
-      { accessor: "description", cell: "Description", classNames: ["description"], maxWidth: 100 },
-      { accessor: "name", cell: "Name", classNames: ["name"], maxWidth: 100 },
+      { accessor: "description", cell: "Description", classNames: ["description"] },
+      { accessor: "name", cell: "Name", classNames: ["name"] },
       { accessor: "category", cell: "Category", classNames: ["category"] },
     ],
     rows: [
-      {
-        id: 271,
-        description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
-        name: "Test",
-        category: "Test",
-        code: "Test",
-      },
+      { id: 271, description: "Test", name: "Test", category: "Test", code: "Test" },
       { id: 272, description: "Test", name: "Test", category: "Test", code: "Test" },
-      {
-        id: 273,
-        description: "Test",
-        name: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
-        category: "Test",
-        code: "Test",
-      },
+      { id: 273, description: "Test", name: "Test", category: "Test", code: "Test" },
       { id: 274, description: "Test", name: "Test", category: "Test", code: "Test" },
     ],
     emptyState: {
@@ -76,26 +64,6 @@ WithRowSelection.args = {
   selectable: true,
   onRowSelect: (selectedRows: Row[]) => console.log(selectedRows),
   onRowClick: (row: Row) => console.log(row),
-};
-
-export const WithoutData = Template.bind({});
-
-WithoutData.args = {
-  rows: [],
-  emptyState: {
-    ...emptyState,
-    hideInfo: true,
-    footer: (
-      <div className="body">
-        <Text fontSize="lg">{emptyState.title}</Text>
-        <br />
-        <Text fontSize="lg">{emptyState.info}</Text>
-        <Button variant="link" className="link-text" onClick={emptyState.callbackFn}>
-          <Text fontSize="lg">{emptyState.callbackInfo}</Text>
-        </Button>
-      </div>
-    ),
-  },
 };
 
 export const WithOverflowColumns = Template.bind({});
@@ -133,4 +101,24 @@ WithOverflowColumns.args = {
     },
     { id: 274, description: "Test", name: "Test", category: "Test", code: "Test" },
   ],
+};
+
+export const WithoutData = Template.bind({});
+
+WithoutData.args = {
+  rows: [],
+  emptyState: {
+    ...emptyState,
+    hideInfo: true,
+    footer: (
+      <div className="body">
+        <Text fontSize="lg">{emptyState.title}</Text>
+        <br />
+        <Text fontSize="lg">{emptyState.info}</Text>
+        <Button variant="link" className="link-text" onClick={emptyState.callbackFn}>
+          <Text fontSize="lg">{emptyState.callbackInfo}</Text>
+        </Button>
+      </div>
+    ),
+  },
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -31,11 +31,7 @@ export default {
     rows: [
       {
         id: 271,
-        description: (
-          <div className="has-overflow">
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry.
-          </div>
-        ),
+        description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
         name: "Test",
         category: "Test",
         code: "Test",
@@ -44,11 +40,7 @@ export default {
       {
         id: 273,
         description: "Test",
-        name: (
-          <div className="has-overflow">
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry.
-          </div>
-        ),
+        name: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
         category: "Test",
         code: "Test",
       },
@@ -104,4 +96,41 @@ WithoutData.args = {
       </div>
     ),
   },
+};
+
+export const WithOverflowColumns = Template.bind({});
+
+WithOverflowColumns.args = {
+  columns: [
+    { accessor: "id", cell: "Code", classNames: ["id"] },
+    { accessor: "description", cell: "Description", classNames: ["description"], maxWidth: 100 },
+    { accessor: "name", cell: "Name", classNames: ["name"], maxWidth: 100 },
+    { accessor: "category", cell: "Category", classNames: ["category"] },
+  ],
+  rows: [
+    {
+      id: 271,
+      description: (
+        <div className="has-overflow">
+          Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+        </div>
+      ),
+      name: "Test",
+      category: "Test",
+      code: "Test",
+    },
+    { id: 272, description: "Test", name: "Test", category: "Test", code: "Test" },
+    {
+      id: 273,
+      description: "Test",
+      name: (
+        <div className="has-overflow">
+          Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+        </div>
+      ),
+      category: "Test",
+      code: "Test",
+    },
+    { id: 274, description: "Test", name: "Test", category: "Test", code: "Test" },
+  ],
 };

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Table> matches snapshot 1`] = `
 <div>
   <div
-    class="css-sy84m1-tableContainer-tableContainer"
+    class="css-yhq98i-tableContainer-tableContainer"
     data-testid="table"
   >
     <table>
@@ -12,30 +12,54 @@ exports[`<Table> matches snapshot 1`] = `
           <th
             class="header-cell header1"
           >
-            <span>
-              Header1
-            </span>
+            <div
+              aria-expanded="false"
+            >
+              <span>
+                <span>
+                  Header1
+                </span>
+              </span>
+            </div>
           </th>
           <th
             class="header-cell header2"
           >
-            <span>
-              Header2
-            </span>
+            <div
+              aria-expanded="false"
+            >
+              <span>
+                <span>
+                  Header2
+                </span>
+              </span>
+            </div>
           </th>
           <th
             class="header-cell header3"
           >
-            <span>
-              Header3
-            </span>
+            <div
+              aria-expanded="false"
+            >
+              <span>
+                <span>
+                  Header3
+                </span>
+              </span>
+            </div>
           </th>
           <th
             class="header-cell header4"
           >
-            <span>
-              Header4
-            </span>
+            <div
+              aria-expanded="false"
+            >
+              <span>
+                <span>
+                  Header4
+                </span>
+              </span>
+            </div>
           </th>
         </tr>
       </thead>
@@ -43,34 +67,194 @@ exports[`<Table> matches snapshot 1`] = `
         <tr
           class=""
         >
-          <td />
-          <td />
-          <td />
-          <td />
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
         </tr>
         <tr
           class=""
         >
-          <td />
-          <td />
-          <td />
-          <td />
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
         </tr>
         <tr
           class=""
         >
-          <td />
-          <td />
-          <td />
-          <td />
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
         </tr>
         <tr
           class=""
         >
-          <td />
-          <td />
-          <td />
-          <td />
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/src/components/Table/components/Body.tsx
+++ b/src/components/Table/components/Body.tsx
@@ -70,13 +70,14 @@ const Body: FC<ChildrenProps> = ({
                 {accessors.map((accessor) => {
                   const rowObj = row[accessor];
                   const { maxWidth } = columns.find((column) => column.accessor === accessor) ?? {};
+                  const style = { maxWidth: maxWidth ? `${maxWidth}px` : "auto" };
 
                   if (typeof rowObj === "function") {
                     return (
                       <Cell
                         key={`entry-${row.id}-${accessor}`}
                         onClick={onRowClick ? (): void => onRowClick(row) : undefined}
-                        style={{ maxWidth: maxWidth ? `${maxWidth}px` : "auto" }}
+                        style={style}
                       >
                         {rowObj(row)}
                       </Cell>
@@ -86,7 +87,7 @@ const Body: FC<ChildrenProps> = ({
                     <Cell
                       key={`entry-${row.id}-${accessor}`}
                       onClick={onRowClick ? (): void => onRowClick(row) : undefined}
-                      style={{ maxWidth: maxWidth ? `${maxWidth}px` : "auto" }}
+                      style={style}
                     >
                       {rowObj as string}
                     </Cell>

--- a/src/components/Table/components/Body.tsx
+++ b/src/components/Table/components/Body.tsx
@@ -69,12 +69,14 @@ const Body: FC<ChildrenProps> = ({
 
                 {accessors.map((accessor) => {
                   const rowObj = row[accessor];
+                  const { maxWidth } = columns.find((column) => column.accessor === accessor) ?? {};
 
                   if (typeof rowObj === "function") {
                     return (
                       <Cell
                         key={`entry-${row.id}-${accessor}`}
                         onClick={onRowClick ? (): void => onRowClick(row) : undefined}
+                        style={{ maxWidth: maxWidth ? `${maxWidth}px` : "auto" }}
                       >
                         {rowObj(row)}
                       </Cell>
@@ -84,6 +86,7 @@ const Body: FC<ChildrenProps> = ({
                     <Cell
                       key={`entry-${row.id}-${accessor}`}
                       onClick={onRowClick ? (): void => onRowClick(row) : undefined}
+                      style={{ maxWidth: maxWidth ? `${maxWidth}px` : "auto" }}
                     >
                       {rowObj as string}
                     </Cell>

--- a/src/components/Table/components/Cell.tsx
+++ b/src/components/Table/components/Cell.tsx
@@ -7,25 +7,25 @@ export type CellProps = HTMLAttributes<HTMLTableCellElement> & {
 };
 
 const Cell: FC<CellProps> = ({ children, as: Component = "td", onClick, style, ...rest }) => {
-  const ref = useRef<HTMLDivElement | null>(null);
   const componentRef = useRef<HTMLTableCellElement | null>(null);
+  const overflowRef = useRef<HTMLElement | null>(null);
   const [isOverflowActive, setIsOverflowActive] = useState(false);
 
   useLayoutEffect(() => {
     if (Component === "td" && componentRef.current) {
-      ref.current = componentRef.current.querySelector(".has-overflow");
+      overflowRef.current = componentRef.current.querySelector(".has-overflow");
     }
   }, []);
 
   useEffect(() => {
     if (Component === "td") {
-      const el = ref.current;
+      const el = overflowRef.current;
 
       if (el) {
         setIsOverflowActive(el.offsetWidth < el.scrollWidth);
       }
     }
-  }, [ref]);
+  }, [overflowRef]);
 
   return (
     <Component ref={componentRef} style={style} onClick={onClick} {...rest}>

--- a/src/components/Table/components/Cell.tsx
+++ b/src/components/Table/components/Cell.tsx
@@ -1,14 +1,37 @@
-import React, { FC, HTMLAttributes } from "react";
+import React, { FC, HTMLAttributes, useEffect, useLayoutEffect, useRef, useState } from "react";
+import Tooltip from "../../Tooltip/Tooltip";
 
 export type CellProps = HTMLAttributes<HTMLTableCellElement> & {
   as?: "td" | "th";
   onClick?: () => void;
 };
 
-const Cell: FC<CellProps> = ({ children, as: Component = "td", onClick, ...rest }) => {
+const Cell: FC<CellProps> = ({ children, as: Component = "td", onClick, style, ...rest }) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const componentRef = useRef<HTMLTableCellElement | null>(null);
+  const [isOverflowActive, setIsOverflowActive] = useState(false);
+
+  useLayoutEffect(() => {
+    if (Component === "td" && componentRef.current) {
+      ref.current = componentRef.current.querySelector(".has-overflow");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (Component === "td") {
+      const el = ref.current;
+
+      if (el) {
+        setIsOverflowActive(el.offsetWidth < el.scrollWidth);
+      }
+    }
+  }, [ref]);
+
   return (
-    <Component onClick={onClick} {...rest}>
-      {children}
+    <Component ref={componentRef} style={style} onClick={onClick} {...rest}>
+      <Tooltip content={children} disabled={!isOverflowActive}>
+        <span style={style}>{children}</span>
+      </Tooltip>
     </Component>
   );
 };

--- a/src/components/Table/styles.ts
+++ b/src/components/Table/styles.ts
@@ -72,6 +72,13 @@ export const tableContainer = ({ table }: Theme) => css`
           padding: 1rem 1.5rem;
           position: relative;
 
+          .has-overflow {
+            word-break: break-word;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+          }
+
           .no-wrap {
             white-space: nowrap;
           }

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -8,6 +8,7 @@ export type Column = {
   hidden?: boolean;
   classNames?: string[];
   sortableHeader?: boolean;
+  maxWidth?: number;
 };
 
 export type Row = {


### PR DESCRIPTION
## Description

In a column with maxWidth set, display a tooltip with it's content when there is overflown text.

## Changes

- Add maxWidth prop in Column type
- Show tooltip for overflown content

## Instructions
In order to work the described behaviour must:
- Apply max width in the desired column column
- Have to be add, in the parent of the element that contains the render text, a "has-overflow" class