### PR TITLE
fix: resizing window apply tooltip

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -78,11 +78,7 @@ WithOverflowColumns.args = {
   rows: [
     {
       id: 271,
-      description: (
-        <div className="has-overflow">
-          Lorem Ipsum is simply dummy text of the printing and typesetting industry.
-        </div>
-      ),
+      description: <div className="has-overflow">Testing Testing Testing</div>,
       name: "Test",
       category: "Test",
       code: "Test",

--- a/src/components/Table/components/Body.tsx
+++ b/src/components/Table/components/Body.tsx
@@ -23,14 +23,15 @@ const Body: FC<ChildrenProps> = ({
   const { columns, selected, emptyState } = state;
   const accessors = columns.filter((column) => !column.hidden).map((column) => column.accessor);
   const selectedRows = selected.map((entry) => entry.id);
-  const [size, setSize] = useState([0, 0]);
+  const [size, setSize] = useState([window.innerWidth, window.innerHeight]);
+
+  const updateSize = () => {
+    setSize([window.innerWidth, window.innerHeight]);
+  };
 
   useLayoutEffect(() => {
-    function updateSize() {
-      setSize([window.innerWidth, window.innerHeight]);
-    }
     window.addEventListener("resize", updateSize);
-    updateSize();
+
     return () => window.removeEventListener("resize", updateSize);
   }, []);
 

--- a/src/components/Table/components/Body.tsx
+++ b/src/components/Table/components/Body.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useLayoutEffect, useState } from "react";
 import classNames from "classnames";
 import { Row } from "../types";
 import Checkbox from "../../FormElements/CheckboxGroup/Checkbox";
@@ -23,6 +23,16 @@ const Body: FC<ChildrenProps> = ({
   const { columns, selected, emptyState } = state;
   const accessors = columns.filter((column) => !column.hidden).map((column) => column.accessor);
   const selectedRows = selected.map((entry) => entry.id);
+  const [size, setSize] = useState([0, 0]);
+
+  useLayoutEffect(() => {
+    function updateSize() {
+      setSize([window.innerWidth, window.innerHeight]);
+    }
+    window.addEventListener("resize", updateSize);
+    updateSize();
+    return () => window.removeEventListener("resize", updateSize);
+  }, []);
 
   const handleRowSelection = (e: React.ChangeEvent<HTMLInputElement>, row: Row): void => {
     e.preventDefault();
@@ -78,6 +88,7 @@ const Body: FC<ChildrenProps> = ({
                         key={`entry-${row.id}-${accessor}`}
                         onClick={onRowClick ? (): void => onRowClick(row) : undefined}
                         style={style}
+                        windowSize={size}
                       >
                         {rowObj(row)}
                       </Cell>
@@ -88,6 +99,7 @@ const Body: FC<ChildrenProps> = ({
                       key={`entry-${row.id}-${accessor}`}
                       onClick={onRowClick ? (): void => onRowClick(row) : undefined}
                       style={style}
+                      windowSize={size}
                     >
                       {rowObj as string}
                     </Cell>

--- a/src/components/Table/components/Cell.tsx
+++ b/src/components/Table/components/Cell.tsx
@@ -3,10 +3,18 @@ import Tooltip from "../../Tooltip/Tooltip";
 
 export type CellProps = HTMLAttributes<HTMLTableCellElement> & {
   as?: "td" | "th";
+  windowSize?: number[];
   onClick?: () => void;
 };
 
-const Cell: FC<CellProps> = ({ children, as: Component = "td", onClick, style, ...rest }) => {
+const Cell: FC<CellProps> = ({
+  children,
+  as: Component = "td",
+  onClick,
+  windowSize,
+  style,
+  ...rest
+}) => {
   const componentRef = useRef<HTMLTableCellElement | null>(null);
   const overflowRef = useRef<HTMLElement | null>(null);
   const [isOverflowActive, setIsOverflowActive] = useState(false);
@@ -18,7 +26,7 @@ const Cell: FC<CellProps> = ({ children, as: Component = "td", onClick, style, .
   }, []);
 
   useEffect(() => {
-    function updateView() {
+    function checkOverflow() {
       const el = overflowRef.current;
 
       if (el) {
@@ -27,11 +35,9 @@ const Cell: FC<CellProps> = ({ children, as: Component = "td", onClick, style, .
     }
 
     if (Component === "td") {
-      window.addEventListener("resize", updateView);
-      updateView();
+      checkOverflow();
     }
-    return () => window.removeEventListener("resize", updateView);
-  }, [overflowRef]);
+  }, [overflowRef, windowSize]);
 
   return (
     <Component ref={componentRef} style={style} onClick={onClick} {...rest}>

--- a/src/components/Table/components/Cell.tsx
+++ b/src/components/Table/components/Cell.tsx
@@ -26,16 +26,12 @@ const Cell: FC<CellProps> = ({
   }, []);
 
   useEffect(() => {
-    function checkOverflow() {
+    if (Component === "td") {
       const el = overflowRef.current;
 
       if (el) {
         setIsOverflowActive(el.offsetWidth < el.scrollWidth);
       }
-    }
-
-    if (Component === "td") {
-      checkOverflow();
     }
   }, [overflowRef, windowSize]);
 

--- a/src/components/Table/components/Cell.tsx
+++ b/src/components/Table/components/Cell.tsx
@@ -18,13 +18,19 @@ const Cell: FC<CellProps> = ({ children, as: Component = "td", onClick, style, .
   }, []);
 
   useEffect(() => {
-    if (Component === "td") {
+    function updateView() {
       const el = overflowRef.current;
 
       if (el) {
         setIsOverflowActive(el.offsetWidth < el.scrollWidth);
       }
     }
+
+    if (Component === "td") {
+      window.addEventListener("resize", updateView);
+      updateView();
+    }
+    return () => window.removeEventListener("resize", updateView);
   }, [overflowRef]);
 
   return (


### PR DESCRIPTION
## Description

Resizing window didn't trigger tooltip when needed.

## Fixes

Every time the window resizes now we check again for overflow.