### PR TITLE
fix: two states sorting in tables

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -53,12 +53,6 @@ export const Default = Template.bind({});
 export const WithSorting = Template.bind({});
 
 WithSorting.args = {
-  columns: [
-    { accessor: "id", cell: "Code", classNames: ["id"] },
-    { accessor: "description", cell: "Description", classNames: ["description"] },
-    { accessor: "name", cell: "Name", classNames: ["name"] },
-    { accessor: "category", cell: "Category", classNames: ["category"] },
-  ],
   sorting: { column: "id", isDescending: false },
   onSortingChanged: (sorting: Sorting) => console.log(sorting),
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -54,7 +54,7 @@ export const WithSorting = Template.bind({});
 
 WithSorting.args = {
   sortable: true,
-  sorting: { column: "id", isDescending: true },
+  sorting: { column: "id", isDescending: false },
   onSortingChanged: (sorting: Sorting) => console.log(sorting),
 };
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -53,7 +53,12 @@ export const Default = Template.bind({});
 export const WithSorting = Template.bind({});
 
 WithSorting.args = {
-  sortable: true,
+  columns: [
+    { accessor: "id", cell: "Code", classNames: ["id"] },
+    { accessor: "description", cell: "Description", classNames: ["description"] },
+    { accessor: "name", cell: "Name", classNames: ["name"] },
+    { accessor: "category", cell: "Category", classNames: ["category"] },
+  ],
   sorting: { column: "id", isDescending: false },
   onSortingChanged: (sorting: Sorting) => console.log(sorting),
 };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -4,7 +4,7 @@ import { tableContainer } from "./styles";
 import Body from "./components/Body";
 import Header from "./components/Header";
 import { Actions } from "./constants";
-import { Sorting, TableProps, TableState } from "./types";
+import { TableProps, TableState } from "./types";
 import { ExtendableProps } from "types/utils";
 
 export type Props = ExtendableProps<HTMLAttributes<HTMLTableElement>, TableProps>;
@@ -16,19 +16,14 @@ type TableCompoundProps = {
 };
 
 const Table: FC<Props> & TableCompoundProps = (props) => {
-  const { columns, rows, emptyState, sortable = false, sorting, onRowSelect } = props;
-
-  const defaultSorting: Sorting = sorting ?? {
-    column: sortable ? columns[0].accessor : "",
-    isDescending: false,
-  };
+  const { columns, rows, emptyState, sorting, onRowSelect } = props;
 
   const [state, dispatch] = useReducer(reducer, {
     columns,
     rows,
     emptyState,
     selected: [],
-    sorting: defaultSorting,
+    sorting,
   });
 
   const { selected } = state;

--- a/src/components/Table/components/Header.tsx
+++ b/src/components/Table/components/Header.tsx
@@ -25,15 +25,10 @@ const Header: FC<ChildrenProps> = ({ selectable = false, state, dispatch, onSort
       // new sorting object
       const newSorting: Sorting = {
         column: accesor,
-        isDescending: false,
+        // when select new column to sort apply ascending order
+        // when select the same column change the current order
+        isDescending: sorting.column !== accesor ? false : !sorting.isDescending,
       };
-
-      // sorting the same column
-      if (sorting.column === accesor) {
-        !sorting.isDescending
-          ? (newSorting.isDescending = true)
-          : (newSorting.isDescending = false);
-      }
 
       dispatch({ type: Actions.sortingChanged, payload: newSorting });
       onSortingChanged && onSortingChanged(newSorting);
@@ -69,9 +64,9 @@ const Header: FC<ChildrenProps> = ({ selectable = false, state, dispatch, onSort
                 }}
               >
                 <span>{typeof cell === "string" ? cell : cell({ accessor, cell })}</span>
-                {sorting && sorting?.column === accessor && (
+                {sorting?.column === accessor && (
                   <span className="sorting-icon">
-                    {!sorting?.isDescending ? (
+                    {!sorting.isDescending ? (
                       <IconChevronUpSVG height={20} />
                     ) : (
                       <IconChevronDownSVG height={20} />

--- a/src/components/Table/components/Header.tsx
+++ b/src/components/Table/components/Header.tsx
@@ -36,7 +36,9 @@ const Header: FC<ChildrenProps> = ({
 
       // sorting the same column
       if (sorting.column === accesor) {
-        !sorting.isDescending ? (newSorting.isDescending = true) : (newSorting.column = "");
+        !sorting.isDescending
+          ? (newSorting.isDescending = true)
+          : (newSorting.isDescending = false);
       }
 
       dispatch({ type: Actions.sortingChanged, payload: newSorting });

--- a/src/components/Table/components/Header.tsx
+++ b/src/components/Table/components/Header.tsx
@@ -6,13 +6,7 @@ import { ChildrenProps } from "../Table";
 import { Actions } from "../constants";
 import Cell from "./Cell";
 
-const Header: FC<ChildrenProps> = ({
-  selectable = false,
-  sortable = false,
-  state,
-  dispatch,
-  onSortingChanged,
-}) => {
+const Header: FC<ChildrenProps> = ({ selectable = false, state, dispatch, onSortingChanged }) => {
   const { rows, columns, selected, sorting } = state;
   const selectedIds = selected.map((entry) => entry.id);
   const rowIds = rows.map((row) => row.id);
@@ -27,7 +21,7 @@ const Header: FC<ChildrenProps> = ({
   };
 
   const handleSortingChange = (accesor: string): void => {
-    if (sortable) {
+    if (sorting) {
       // new sorting object
       const newSorting: Sorting = {
         column: accesor,
@@ -75,7 +69,7 @@ const Header: FC<ChildrenProps> = ({
                 }}
               >
                 <span>{typeof cell === "string" ? cell : cell({ accessor, cell })}</span>
-                {sortable && sorting?.column === accessor && (
+                {sorting && sorting?.column === accessor && (
                   <span className="sorting-icon">
                     {!sorting?.isDescending ? (
                       <IconChevronUpSVG height={20} />

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -24,12 +24,10 @@ export type EmptyState = {
   hideInfo?: boolean;
 };
 
-export type Sorting =
-  | {
-      column: string;
-      isDescending: boolean;
-    }
-  | undefined;
+export type Sorting = {
+  column: string;
+  isDescending: boolean;
+};
 
 export type TableProps = {
   columns: Column[];
@@ -48,7 +46,7 @@ export type TableState = {
   rows: Row[];
   emptyState: EmptyState;
   selected: Row[];
-  sorting: Sorting;
+  sorting?: Sorting;
 };
 
 export type ActionType =

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -24,17 +24,18 @@ export type EmptyState = {
   hideInfo?: boolean;
 };
 
-export type Sorting = {
-  column: string;
-  isDescending: boolean;
-};
+export type Sorting =
+  | {
+      column: string;
+      isDescending: boolean;
+    }
+  | undefined;
 
 export type TableProps = {
   columns: Column[];
   rows: Row[];
   emptyState: EmptyState;
   selectable?: boolean;
-  sortable?: boolean;
   sorting?: Sorting;
   onSortingChanged?: (sorting: Sorting) => void;
   onRowSelect?: (selectedRows: Row[]) => void;


### PR DESCRIPTION
## Description

We want to only use 2 states when sorting a column in tables.

## Changes

States are now ascending and descending only.

## Fixes

The no sorting state is removed.
