### PR TITLE
Refactor Tabs

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,40 +1,54 @@
 import React from "react";
 import { Story } from "@storybook/react";
-import { Heading } from "../../";
+import Heading from "../Heading/Heading";
 import Tabs from "./Tabs";
 
 export default {
   title: "Components/Tabs",
 };
 
-const Template: Story = (args) => (
-  <Tabs {...args}>
-    <Tabs.TabPane title="Completed courses">
+const tabs = [
+  {
+    title: "Completed courses",
+    content: (
       <div style={{ padding: "2rem" }}>
         <Heading>Completed courses</Heading>
         <p>Completed courses content!</p>
       </div>
-    </Tabs.TabPane>
-    <Tabs.TabPane title="My super points">
+    ),
+  },
+  {
+    title: "My super points",
+    content: (
       <div style={{ padding: "2rem" }}>
         <Heading>My super points</Heading>
         <p>My super points content!</p>
       </div>
-    </Tabs.TabPane>
-    <Tabs.TabPane title="My superior level">
+    ),
+  },
+  {
+    title: "My superior level",
+    content: (
       <div style={{ padding: "2rem" }}>
         <Heading>My superior level</Heading>
         <p>My superior level content!</p>
       </div>
-    </Tabs.TabPane>
-    <Tabs.TabPane title="I have a lot of certifications">
+    ),
+  },
+  {
+    title: "I have a lot of certifications",
+    content: (
       <div style={{ padding: "2rem" }}>
         <Heading>I have a lot of certifications</Heading>
         <p>I have a lot of certifications content!</p>
       </div>
-    </Tabs.TabPane>
-  </Tabs>
-);
+    ),
+  },
+];
+
+const Template: Story = (args) => {
+  return <Tabs {...args} tabs={tabs} />;
+};
 
 export const Basic = Template.bind({});
 
@@ -69,32 +83,7 @@ OnChangeTab.args = {
 
 const ResponsiveTemplate: Story = (args) => (
   <div style={{ maxWidth: "500px", border: "1px solid red" }}>
-    <Tabs {...args}>
-      <Tabs.TabPane title="Completed courses">
-        <div style={{ padding: "2rem" }}>
-          <Heading>Completed courses</Heading>
-          <p>Completed courses content!</p>
-        </div>
-      </Tabs.TabPane>
-      <Tabs.TabPane title="My super points">
-        <div style={{ padding: "2rem" }}>
-          <Heading>My super points</Heading>
-          <p>My super points content!</p>
-        </div>
-      </Tabs.TabPane>
-      <Tabs.TabPane title="My superior level">
-        <div style={{ padding: "2rem" }}>
-          <Heading>My superior level</Heading>
-          <p>My superior level content!</p>
-        </div>
-      </Tabs.TabPane>
-      <Tabs.TabPane title="I have a lot of certifications">
-        <div style={{ padding: "2rem" }}>
-          <Heading>I have a lot of certifications</Heading>
-          <p>I have a lot of certifications content!</p>
-        </div>
-      </Tabs.TabPane>
-    </Tabs>
+    <Tabs {...args} tabs={tabs} />
   </div>
 );
 

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import { faker } from "@faker-js/faker";
-import Tabs from "./Tabs";
+import Tabs, { TabObject } from "./Tabs";
 import { screen, render } from "@test-utils/render";
 
 const getTabsProps = () => ({
@@ -19,13 +19,23 @@ window.HTMLElement.prototype.scrollIntoView = jest.fn();
 describe("<Tabs/>", () => {
   it("renders correctly", () => {
     const { tab1Txt, tab2Txt, tab3Txt, tab1TitleTxt, tab2TitleTxt, tab3TitleTxt } = getTabsProps();
-    render(
-      <Tabs>
-        <Tabs.TabPane title={tab1TitleTxt}>{tab1Txt}</Tabs.TabPane>
-        <Tabs.TabPane title={tab2TitleTxt}>{tab2Txt}</Tabs.TabPane>
-        <Tabs.TabPane title={tab3TitleTxt}>{tab3Txt}</Tabs.TabPane>
-      </Tabs>,
-    );
+
+    const tabs: TabObject[] = [
+      {
+        title: tab1TitleTxt,
+        content: tab1Txt,
+      },
+      {
+        title: tab2TitleTxt,
+        content: tab2Txt,
+      },
+      {
+        title: tab3TitleTxt,
+        content: tab3Txt,
+      },
+    ];
+
+    render(<Tabs tabs={tabs} />);
 
     const titles = screen.getAllByRole("tab");
     const tab1Content = screen.getByText(tab1Txt);
@@ -38,13 +48,17 @@ describe("<Tabs/>", () => {
 
   it("changes tabs correctly", () => {
     const { tab1Txt, tab2Txt, tab1TitleTxt, tab2TitleTxt } = getTabsProps();
-
-    render(
-      <Tabs>
-        <Tabs.TabPane title={tab1TitleTxt}>{tab1Txt}</Tabs.TabPane>
-        <Tabs.TabPane title={tab2TitleTxt}>{tab2Txt}</Tabs.TabPane>
-      </Tabs>,
-    );
+    const tabs: TabObject[] = [
+      {
+        title: tab1TitleTxt,
+        content: tab1Txt,
+      },
+      {
+        title: tab2TitleTxt,
+        content: tab2Txt,
+      },
+    ];
+    render(<Tabs tabs={tabs} />);
 
     const tab2 = screen.getByText(tab2TitleTxt);
 
@@ -57,13 +71,23 @@ describe("<Tabs/>", () => {
 
   it("render with initial tab value", () => {
     const { tab1Txt, tab2Txt, tab3Txt, tab1TitleTxt, tab2TitleTxt, tab3TitleTxt } = getTabsProps();
-    render(
-      <Tabs selectedTab={1}>
-        <Tabs.TabPane title={tab1TitleTxt}>{tab1Txt}</Tabs.TabPane>
-        <Tabs.TabPane title={tab2TitleTxt}>{tab2Txt}</Tabs.TabPane>
-        <Tabs.TabPane title={tab3TitleTxt}>{tab3Txt}</Tabs.TabPane>
-      </Tabs>,
-    );
+
+    const tabs: TabObject[] = [
+      {
+        title: tab1TitleTxt,
+        content: tab1Txt,
+      },
+      {
+        title: tab2TitleTxt,
+        content: tab2Txt,
+      },
+      {
+        title: tab3TitleTxt,
+        content: tab3Txt,
+      },
+    ];
+
+    render(<Tabs selectedTab={1} tabs={tabs} />);
     const tab2 = screen.getByText(tab2TitleTxt);
     const tab2Content = screen.getByText(tab2Txt);
 
@@ -74,13 +98,23 @@ describe("<Tabs/>", () => {
   it("to get tab index with `onChangeTab` callback", () => {
     const mockFn = jest.fn();
     const { tab1Txt, tab2Txt, tab3Txt, tab1TitleTxt, tab2TitleTxt, tab3TitleTxt } = getTabsProps();
-    render(
-      <Tabs onChangeTab={mockFn}>
-        <Tabs.TabPane title={tab1TitleTxt}>{tab1Txt}</Tabs.TabPane>
-        <Tabs.TabPane title={tab2TitleTxt}>{tab2Txt}</Tabs.TabPane>
-        <Tabs.TabPane title={tab3TitleTxt}>{tab3Txt}</Tabs.TabPane>
-      </Tabs>,
-    );
+
+    const tabs: TabObject[] = [
+      {
+        title: tab1TitleTxt,
+        content: tab1Txt,
+      },
+      {
+        title: tab2TitleTxt,
+        content: tab2Txt,
+      },
+      {
+        title: tab3TitleTxt,
+        content: tab3Txt,
+      },
+    ];
+
+    render(<Tabs onChangeTab={mockFn} tabs={tabs} />);
     const tab2 = screen.getByText(tab2TitleTxt);
     const tab3 = screen.getByText(tab3TitleTxt);
 
@@ -96,25 +130,43 @@ describe("<Tabs/>", () => {
   });
 
   it("matches snapshot", () => {
-    const { container } = render(
-      <Tabs id="tab-1" className="tabs">
-        <Tabs.TabPane title="Tab 1">Test tab 1</Tabs.TabPane>
-        <Tabs.TabPane title="Tab 2">Test tab 2</Tabs.TabPane>
-        <Tabs.TabPane title="Tab 3">Test tab 3</Tabs.TabPane>
-      </Tabs>,
-    );
+    const tabs = [
+      {
+        title: "Tab 1",
+        content: "Test tab 1",
+      },
+      {
+        title: "Tab 2",
+        content: "Test tab 2",
+      },
+      {
+        title: "Tab 3",
+        content: "Test tab 3",
+      },
+    ];
+
+    const { container } = render(<Tabs id="tab-1" className="tabs" tabs={tabs} />);
 
     expect(container).toMatchSnapshot();
   });
 
   it("matches snapshot with stickyHeader", () => {
-    const { container } = render(
-      <Tabs stickyHeader>
-        <Tabs.TabPane title="Tab 1">Test tab 1</Tabs.TabPane>
-        <Tabs.TabPane title="Tab 2">Test tab 2</Tabs.TabPane>
-        <Tabs.TabPane title="Tab 3">Test tab 3</Tabs.TabPane>
-      </Tabs>,
-    );
+    const tabs = [
+      {
+        title: "Tab 1",
+        content: "Test tab 1",
+      },
+      {
+        title: "Tab 2",
+        content: "Test tab 2",
+      },
+      {
+        title: "Tab 3",
+        content: "Test tab 3",
+      },
+    ];
+
+    const { container } = render(<Tabs stickyHeader tabs={tabs} />);
 
     expect(container).toMatchSnapshot();
   });

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -6,9 +6,9 @@ import TabsNavItem from "./TabsNavItem";
 import TabsContent from "./TabsContent";
 import { container, tabsHeader } from "./styles";
 
-type TabObject = {
+export type TabObject = {
   title: JSX.Element | string;
-  content: JSX.Element;
+  content: JSX.Element | string;
 };
 
 type TabsProps = React.HTMLAttributes<HTMLElement> & {
@@ -19,7 +19,7 @@ type TabsProps = React.HTMLAttributes<HTMLElement> & {
 };
 
 const Tabs: FC<TabsProps> = ({
-  tabs,
+  tabs = [],
   stickyHeader = false,
   selectedTab = 0,
   onChangeTab,

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -50,13 +50,12 @@ const Tabs: FC<TabsProps> = ({
   };
 
   const showRightArrow = () => {
-    if (!isOverflowActive) return false;
-    if (!tabs) return false;
+    if (!isOverflowActive || !tabs.length) return false;
     return activeTab < tabsLength;
   };
 
   const handRightArrowClick = () => {
-    if (tabs && activeTab < tabsLength) {
+    if (tabs.length && activeTab < tabsLength) {
       scrollToTab(activeTab + 1);
       setActiveTab((currentTab) => currentTab + 1);
     }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -26,6 +26,7 @@ const Tabs: FC<TabsProps> = ({
   ...rest
 }) => {
   const [activeTab, setActiveTab] = useState(selectedTab);
+  const tabsLength = tabs.length - 1;
   const tabsNavEl = useRef<HTMLElement>(null);
   const [isOverflowActive, setIsOverflowActive] = useState(false);
   const dir = document.dir;
@@ -51,11 +52,11 @@ const Tabs: FC<TabsProps> = ({
   const showRightArrow = () => {
     if (!isOverflowActive) return false;
     if (!tabs) return false;
-    return activeTab < tabs.length - 1;
+    return activeTab < tabsLength;
   };
 
   const handRightArrowClick = () => {
-    if (tabs && activeTab < tabs.length - 1) {
+    if (tabs && activeTab < tabsLength) {
       scrollToTab(activeTab + 1);
       setActiveTab((currentTab) => currentTab + 1);
     }
@@ -68,8 +69,8 @@ const Tabs: FC<TabsProps> = ({
       newSelectedTab = 0;
     }
 
-    if (selectedTab > tabs.length - 1) {
-      newSelectedTab = tabs.length - 1;
+    if (selectedTab > tabsLength) {
+      newSelectedTab = tabsLength;
     }
 
     setActiveTab(newSelectedTab);

--- a/src/components/Tabs/TabsNavItem.tsx
+++ b/src/components/Tabs/TabsNavItem.tsx
@@ -5,7 +5,7 @@ import { tabNavItem } from "./styles";
 
 type TabsNavItemProps = {
   index: number;
-  title: string;
+  title: string | JSX.Element;
   isActive: boolean;
   onSelectTab: (i: number) => void;
 };


### PR DESCRIPTION
Improve the way we handle tab props as it previously could lead to unexpected behavior

BREAKING CHANGE: You need to refactor your <Tabs> component with suitable props. No more passing content as children.


