### PR TITLE
feat: extra changes to select component 

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -72,7 +72,6 @@ const Dropdown: FC<DropdownProps> = ({
                 {item.label}
               </Text>
             </li>
-
             {renderItemsRecursively(item.items, level + 1)}
           </Fragment>
         );

--- a/src/components/FormElements/Select/Select.tsx
+++ b/src/components/FormElements/Select/Select.tsx
@@ -193,7 +193,7 @@ const Select: ForwardRefRenderFunction<
           }}
           isSearchable={false}
           maxMenuHeight={maxMenuHeight}
-          menuIsOpen={isFocused || undefined || true}
+          menuIsOpen={isFocused || undefined}
           options={options}
           placeholder={outerPlaceholder}
           styles={styles}

--- a/src/components/FormElements/Select/Select.tsx
+++ b/src/components/FormElements/Select/Select.tsx
@@ -48,6 +48,9 @@ const Select: ForwardRefRenderFunction<
     hasInnerSearch = false,
     innerPlaceholder = INNER_PLACEHOLDER,
     placeholder: outerPlaceholder = OUTER_PLACEHOLDER,
+    isInlineFlex = false,
+    minWidth = "5rem",
+    maxWidth = "50rem",
     onChange,
     ...rest
   } = props;
@@ -58,6 +61,12 @@ const Select: ForwardRefRenderFunction<
   const [inputValue, setInputValue] = useState("");
 
   const styles = {
+    menu: (base: CSSObjectWithLabel) => {
+      return {
+        ...base,
+        zIndex: 3,
+      };
+    },
     placeholder: (
       base: CSSObjectWithLabel,
       { isDisabled }: PlaceholderProps<CustomOption, boolean, GroupBase<CustomOption>>,
@@ -157,7 +166,11 @@ const Select: ForwardRefRenderFunction<
   );
 
   return (
-    <div css={(theme): SerializedStyles => selectContainer(theme, { size, inline })}>
+    <div
+      css={(theme): SerializedStyles =>
+        selectContainer(theme, { size, inline, isInlineFlex, minWidth, maxWidth })
+      }
+    >
       {hasLabel && (
         <Label htmlFor={id} aria-labelledby={id}>
           {label}
@@ -180,7 +193,7 @@ const Select: ForwardRefRenderFunction<
           }}
           isSearchable={false}
           maxMenuHeight={maxMenuHeight}
-          menuIsOpen={isFocused || undefined}
+          menuIsOpen={isFocused || undefined || true}
           options={options}
           placeholder={outerPlaceholder}
           styles={styles}

--- a/src/components/FormElements/Select/styles.ts
+++ b/src/components/FormElements/Select/styles.ts
@@ -10,22 +10,37 @@ const optionPadding = {
 
 export const selectContainer = (
   { formElements }: Theme,
-  { size, inline }: { size: InputSize; inline: boolean },
+  {
+    size,
+    inline,
+    isInlineFlex,
+    minWidth,
+    maxWidth,
+  }: {
+    size: InputSize;
+    inline: boolean;
+    isInlineFlex: boolean;
+    minWidth: string;
+    maxWidth: string;
+  },
 ): SerializedStyles => css`
-  display: flex;
+  display: ${isInlineFlex ? "inline-flex" : "flex"};
   flex-direction: ${inline ? "row" : "column"};
   gap: ${inline ? "1rem" : "0.5rem"};
   align-items: ${inline ? "center" : "normal"};
 
   label {
     margin: 0;
+    margin-inline-start: ${inline ? "0" : "0.5rem"};
   }
 
   .select-input-wrapper {
+    min-width: ${minWidth};
+    max-width: ${maxWidth};
     flex-grow: 1;
-    max-width: 25rem;
     background-color: ${formElements.input.background};
     border-radius: 0.3125rem;
+
     .error {
       border-color: ${formElements.errors.errorBorderColor};
     }

--- a/src/components/FormElements/Select/types.ts
+++ b/src/components/FormElements/Select/types.ts
@@ -34,6 +34,9 @@ export type CustomSelectProps<
   status?: "valid" | "error";
   hasInnerSearch?: boolean;
   innerPlaceholder?: string;
+  isInlineFlex?: boolean;
+  minWidth?: string;
+  maxWidth?: string;
 };
 
 export type CustomMenuListProps<


### PR DESCRIPTION
## Description

- Increase the z-index of the custom menu to avoid things shown in the background.
- Add `margin-inline-start: 0.5rem;` to label when not inline.
- Fill the gap questions require `display: inline-flex` instead of `flex`
- Add min-width and max-width props and styles
