### PR TITLE
fix: centering tooltip arrow

### DIFF
--- a/src/components/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/Chip/__snapshots__/Chip.test.tsx.snap
@@ -19,7 +19,9 @@ exports[`<Chip /> matches snapshot 1`] = `
         />
       </span>
     </button>
-    <div>
+    <div
+      aria-expanded="false"
+    >
       <div
         class="has-overflow"
       >

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -13,7 +13,9 @@ exports[`<Table> matches snapshot 1`] = `
             class="header-cell header1 false"
             style="width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="width: auto;"
               >
@@ -27,7 +29,9 @@ exports[`<Table> matches snapshot 1`] = `
             class="header-cell header2 false"
             style="width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="width: auto;"
               >
@@ -41,7 +45,9 @@ exports[`<Table> matches snapshot 1`] = `
             class="header-cell header3 false"
             style="width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="width: auto;"
               >
@@ -55,7 +61,9 @@ exports[`<Table> matches snapshot 1`] = `
             class="header-cell header4 false"
             style="width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="width: auto;"
               >
@@ -69,7 +77,9 @@ exports[`<Table> matches snapshot 1`] = `
             class="header-cell header5 false"
             style="width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="width: auto;"
               >
@@ -88,7 +98,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -97,7 +109,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -106,7 +120,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -115,7 +131,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -124,56 +142,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
-              <span
-                style="max-width: auto;"
-              />
-            </div>
-          </td>
-        </tr>
-        <tr
-          class=""
-        >
-          <td
-            style="max-width: auto;"
-          >
-            <div>
-              <span
-                style="max-width: auto;"
-              />
-            </div>
-          </td>
-          <td
-            style="max-width: auto;"
-          >
-            <div>
-              <span
-                style="max-width: auto;"
-              />
-            </div>
-          </td>
-          <td
-            style="max-width: auto;"
-          >
-            <div>
-              <span
-                style="max-width: auto;"
-              />
-            </div>
-          </td>
-          <td
-            style="max-width: auto;"
-          >
-            <div>
-              <span
-                style="max-width: auto;"
-              />
-            </div>
-          </td>
-          <td
-            style="max-width: auto;"
-          >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -186,7 +157,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -195,7 +168,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -204,7 +179,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -213,7 +190,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -222,7 +201,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -235,7 +216,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -244,7 +227,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -253,7 +238,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -262,7 +249,9 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />
@@ -271,7 +260,68 @@ exports[`<Table> matches snapshot 1`] = `
           <td
             style="max-width: auto;"
           >
-            <div>
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
+              <span
+                style="max-width: auto;"
+              />
+            </div>
+          </td>
+          <td
+            style="max-width: auto;"
+          >
+            <div
+              aria-expanded="false"
+            >
               <span
                 style="max-width: auto;"
               />

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -14,6 +14,7 @@ const Tooltip: FC<TooltipProps> = ({
   as = "div",
   placement = "top",
   maxWidth = 350,
+  interactive = true,
   ...rest
 }) => {
   const Tag = as;
@@ -21,6 +22,7 @@ const Tooltip: FC<TooltipProps> = ({
   return (
     <Tippy
       placement={placement}
+      interactive={interactive}
       render={(attrs): ReactNode => (
         <div className="tooltip" css={(theme) => tooltipContainer(maxWidth, theme)} {...attrs}>
           {content}

--- a/src/components/Tooltip/styles.ts
+++ b/src/components/Tooltip/styles.ts
@@ -14,19 +14,29 @@ export const tooltipContainer = (
     font-size: ${typeScaleSizes["2xs"]};
 
     &.tooltip[data-placement^="top"] > #arrow {
+      margin-left: -2px;
       bottom: -1px;
     }
 
     &.tooltip[data-placement^="bottom"] > #arrow {
       top: -1px;
+      margin-left: 3px;
     }
 
     &.tooltip[data-placement^="left"] > #arrow {
       right: -4px;
+      margin-top: -2px;
     }
 
     &.tooltip[data-placement^="right"] > #arrow {
       left: -4px;
+      margin-top: 3px;
+    }
+
+    #arrow {
+      svg {
+        text-align: center;
+      }
     }
 
     #arrow,

--- a/src/components/Tooltip/styles.ts
+++ b/src/components/Tooltip/styles.ts
@@ -33,12 +33,6 @@ export const tooltipContainer = (
       margin-top: 3px;
     }
 
-    #arrow {
-      svg {
-        text-align: center;
-      }
-    }
-
     #arrow,
     #arrow::before {
       position: absolute;


### PR DESCRIPTION
## Description

The tooltip arrow needs to be centered in tippy component.

## Changes

Adding tippy prop(interactive) to keep tooltip visible when hovering.

## Fixes

Adding some margins to make arrow centered for every tooltip placement.
