### PR TITLE
fix: rename link button class

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -66,6 +66,7 @@ const Button = <C extends ElementType = "button">(props: ButtonProps<C>): ReactE
     disabled,
     ...rest
   } = props;
+
   const Component = as || "button";
   const PrefixIcon = iconBefore;
   const SuffixIcon = iconAfter;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -76,7 +76,7 @@ const Button = <C extends ElementType = "button">(props: ButtonProps<C>): ReactE
     solid: variant === "solid",
     outline: variant === "outline",
     ghost: variant === "ghost",
-    link: variant === "link",
+    linkButton: variant === "link",
     "icon-after": SuffixIcon,
     "icon-before": PrefixIcon,
   });

--- a/src/components/Button/styles.ts
+++ b/src/components/Button/styles.ts
@@ -204,7 +204,7 @@ export const btnContainer = (
       ${ghostButton(button, color)};
     }
 
-    &.link {
+    &.linkButton {
       ${linkButton(button, color)};
     }
 


### PR DESCRIPTION
## Description

Bug cause due to having rules with the same name

## Changes

Change the name of link button class


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205820631366084