### PR TITLE
Feat/allow jsx in tooltip and handle readonly

### DIFF
--- a/src/components/FormElements/CheckboxGroup/Checkbox.tsx
+++ b/src/components/FormElements/CheckboxGroup/Checkbox.tsx
@@ -33,13 +33,14 @@ const Checkbox: ForwardRefRenderFunction<HTMLDivElement, CheckboxProps> = (props
     inline = false,
     containerAttrs,
     isPartiallySelected,
+    readOnly = false,
     ...rest
   } = props;
 
   return (
     <div
       ref={ref}
-      css={(theme): SerializedStyles => checkboxContainer(theme, { size, inline })}
+      css={(theme): SerializedStyles => checkboxContainer(theme, { size, inline, readOnly })}
       {...containerAttrs}
     >
       {isPartiallySelected && <span data-testid="is-partially-selected" className="dash" />}

--- a/src/components/FormElements/CheckboxGroup/styles.ts
+++ b/src/components/FormElements/CheckboxGroup/styles.ts
@@ -40,7 +40,7 @@ export const checkboxGroupContainer = (inline: boolean): SerializedStyles => css
 
 export const checkboxContainer = (
   { typeScaleSizes, formElements }: Theme,
-  { size, inline }: { size: CheckboxSize; inline: boolean },
+  { size, inline, readOnly }: { size: CheckboxSize; inline: boolean; readOnly: boolean },
 ): SerializedStyles => {
   const fontSizes = {
     md: typeScaleSizes.sm,
@@ -71,7 +71,9 @@ export const checkboxContainer = (
       &:focus,
       &:hover {
         + label > .shadow-element {
-          box-shadow: 0px 0px 0px 9px ${formElements.checkbox.input.shadowColor};
+          box-shadow: ${readOnly
+            ? 0
+            : `0px 0px 0px 9px ${formElements.checkbox.input.shadowColor}`};
         }
       }
 
@@ -106,7 +108,7 @@ export const checkboxContainer = (
         display: flex;
         padding-inline-start: 1.5rem;
         font-size: ${fontSizes[size]};
-        cursor: pointer;
+        cursor: ${readOnly ? "normal" : "pointer"};
 
         .required::after {
           display: inline-block;

--- a/src/components/FormElements/Input/Input.stories.tsx
+++ b/src/components/FormElements/Input/Input.stories.tsx
@@ -109,6 +109,7 @@ export const WithIconAfter = InputTemplate.bind({});
 
 WithIconAfter.args = {
   iconAfter: CalendarSVG,
+  tooltipContent: <div> This is an html tooltip </div>,
 };
 
 export const WithIconAfterNoVerticalLine = InputTemplate.bind({});

--- a/src/components/FormElements/Input/Input.tsx
+++ b/src/components/FormElements/Input/Input.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   MouseEvent,
   useEffect,
+  isValidElement,
 } from "react";
 import classNames from "classnames";
 import { SerializedStyles } from "@emotion/react";
@@ -30,7 +31,7 @@ export type InputProps = ExtendableProps<
     inline?: boolean;
     containerAttrs?: React.HTMLAttributes<HTMLDivElement>;
     css?: SerializedStyles;
-    tooltipContent?: string;
+    tooltipContent?: string | JSX.Element;
     showVerticalLine?: boolean;
     isClearable?: boolean;
     autoFocus?: boolean;
@@ -98,6 +99,10 @@ const Input: ForwardRefRenderFunction<HTMLInputElement, InputProps> = (
     setFocus();
   };
 
+  const shouldRenderTooltip =
+    (tooltipContent && typeof tooltipContent === "string" && tooltipContent !== "") ||
+    isValidElement(tooltipContent);
+
   return (
     <div
       css={(theme): SerializedStyles =>
@@ -116,7 +121,7 @@ const Input: ForwardRefRenderFunction<HTMLInputElement, InputProps> = (
           <Label htmlFor={id} className={labelClassname}>
             {label}
           </Label>
-          {tooltipContent?.length > 0 && (
+          {shouldRenderTooltip && (
             <Tooltip content={tooltipContent}>
               <InfoCircledSVG height={20} />
             </Tooltip>

--- a/src/components/FormElements/RadioGroup/Radio.tsx
+++ b/src/components/FormElements/RadioGroup/Radio.tsx
@@ -26,10 +26,11 @@ const Radio: FC<RadioProps> = ({
   size = "md",
   inline = false,
   containerAttrs,
+  readOnly = false,
   ...rest
 }) => (
   <div
-    css={(theme): SerializedStyles => radioButtonContainer(theme, { size, inline })}
+    css={(theme): SerializedStyles => radioButtonContainer(theme, { size, inline, readOnly })}
     {...containerAttrs}
   >
     <input id={id} type="radio" {...rest} />

--- a/src/components/FormElements/RadioGroup/styles.ts
+++ b/src/components/FormElements/RadioGroup/styles.ts
@@ -11,7 +11,7 @@ export const container = (inline: boolean): SerializedStyles => css`
 
 export const radioButtonContainer = (
   { typeScaleSizes, formElements: { checkbox } }: Theme,
-  { size, inline }: { size: InputSize; inline: boolean },
+  { size, inline, readOnly }: { size: InputSize; inline: boolean; readOnly: boolean },
 ): SerializedStyles => {
   const fontSizes = {
     md: typeScaleSizes.sm,
@@ -28,7 +28,7 @@ export const radioButtonContainer = (
       &:focus,
       &:hover {
         + label::before {
-          box-shadow: 0px 0px 0px 9px ${checkbox.input.shadowColor};
+          box-shadow: ${readOnly ? 0 : `0px 0px 0px 9px ${checkbox.input.shadowColor}`};
         }
       }
 
@@ -58,7 +58,7 @@ export const radioButtonContainer = (
         position: relative;
         display: inline-block;
         padding-inline-start: 1.5rem;
-        cursor: pointer;
+        cursor: ${readOnly ? "normal" : "pointer"};
 
         &::before {
           content: "";


### PR DESCRIPTION
## Description

1. Allow JSX in the tooltip content for inputs.
2. Handle read-only appearance in checkboxes and radio buttons.
