### PR TITLE
fix: validating new input values on select component

### DIFF
--- a/src/components/FormElements/Select/Select.stories.tsx
+++ b/src/components/FormElements/Select/Select.stories.tsx
@@ -112,6 +112,7 @@ withValueCreation.args = {
   isClearable: true,
   hasInnerSearch: true,
   type: "creatable",
+  isInputValid: (value: string): boolean => !/^\d*$/.test(value),
 };
 
 export const AsyncSelect: Story<CustomSelectProps<CustomOption, boolean>> = (args) => {

--- a/src/components/FormElements/Select/Select.stories.tsx
+++ b/src/components/FormElements/Select/Select.stories.tsx
@@ -112,7 +112,17 @@ withValueCreation.args = {
   isClearable: true,
   hasInnerSearch: true,
   type: "creatable",
-  isInputValid: (value: string): boolean => !/^\d*$/.test(value),
+};
+
+export const withValueCreationValidation = Template.bind({});
+
+withValueCreationValidation.args = {
+  options: defaultOptions,
+  isMulti: true,
+  isClearable: true,
+  hasInnerSearch: true,
+  type: "creatable",
+  isInputValid: (value: string): boolean => /^(?=.*[^\d])(?=.*\S).+$/.test(value),
 };
 
 export const AsyncSelect: Story<CustomSelectProps<CustomOption, boolean>> = (args) => {

--- a/src/components/FormElements/Select/Select.tsx
+++ b/src/components/FormElements/Select/Select.tsx
@@ -57,6 +57,7 @@ const Select: ForwardRefRenderFunction<
     maxWidth = MAX_WIDTH,
     placeholder: outerPlaceholder = OUTER_PLACEHOLDER,
     onChange,
+    isInputValid,
     ...rest
   } = props;
   const hasLabel = Boolean(label);
@@ -126,6 +127,7 @@ const Select: ForwardRefRenderFunction<
       onChange && onChange(option, action);
     },
     onInputChange: (val: string) => setInputValue(val),
+    isValidNewOption: isInputValid,
   };
 
   useClickAway(

--- a/src/components/FormElements/Select/types.ts
+++ b/src/components/FormElements/Select/types.ts
@@ -55,6 +55,7 @@ export type CustomSelectProps<
   maxWidth?: string;
   creatableTooltip?: string;
   asyncOptions?: AsyncOptions;
+  isInputValid?: (input: string) => boolean;
 };
 
 export type CustomMenuListProps<


### PR DESCRIPTION
## Description

The Select component in Gnosis should be allowed to pass as a validation hook as a prop to allow specific new input values.

## Changes

Passing a validation hook that returns boolean type and using it as prop in CreatableSelect.

