### PR TITLE
chore(select): add tooltip content to Select component

### DIFF
--- a/src/components/FormElements/Select/Select.stories.tsx
+++ b/src/components/FormElements/Select/Select.stories.tsx
@@ -12,6 +12,7 @@ export default {
     label: "Choose a programming language",
     inline: false,
     id: "programming-language",
+    tooltipContent: "",
   },
   argTypes: {
     size: {

--- a/src/components/FormElements/Select/Select.tsx
+++ b/src/components/FormElements/Select/Select.tsx
@@ -3,6 +3,7 @@ import React, {
   ForwardRefRenderFunction,
   PropsWithChildren,
   forwardRef,
+  isValidElement,
   useRef,
   useState,
 } from "react";
@@ -20,7 +21,7 @@ import CreatableSelect from "react-select/creatable";
 import { useClickAway } from "ahooks";
 import Label from "../Label/Label";
 import Tooltip from "../../Tooltip/Tooltip";
-import { AddOperatorSVG } from "../../../icons";
+import { AddOperatorSVG, InfoCircledSVG } from "../../../icons";
 import CustomValueContainer from "./components/CustomValueContainer";
 import { resolveStyles, selectContainer } from "./styles";
 import CustomMenuList from "./components/CustomMenuList";
@@ -56,6 +57,7 @@ const Select: ForwardRefRenderFunction<
     minWidth = MIN_WIDTH,
     maxWidth = MAX_WIDTH,
     placeholder: outerPlaceholder = OUTER_PLACEHOLDER,
+    tooltipContent = "",
     onChange,
     ...rest
   } = props;
@@ -84,6 +86,9 @@ const Select: ForwardRefRenderFunction<
   };
 
   const innerSearchEnabled = shouldShowInnerSearch();
+  const shouldRenderTooltip =
+    (tooltipContent && typeof tooltipContent === "string" && tooltipContent !== "") ||
+    isValidElement(tooltipContent);
 
   const styles = resolveStyles(size, hasInnerSearch);
 
@@ -174,9 +179,16 @@ const Select: ForwardRefRenderFunction<
       }
     >
       {hasLabel && (
-        <Label htmlFor={id} aria-labelledby={id} className={labelClassname}>
-          {label}
-        </Label>
+        <div className="label-container">
+          <Label htmlFor={id} aria-labelledby={id} className={labelClassname}>
+            {label}
+          </Label>
+          {shouldRenderTooltip && (
+            <Tooltip content={tooltipContent}>
+              <InfoCircledSVG height={20} />
+            </Tooltip>
+          )}
+        </div>
       )}
 
       <div className="select-input-wrapper" data-testid="custom-react-select" ref={containerRef}>

--- a/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
@@ -3,15 +3,19 @@
 exports[`<Select /> matches snapshot 1`] = `
 <div>
   <div
-    class="css-q6q58u-selectContainer-selectContainer"
+    class="css-1scuon3-selectContainer-selectContainer"
   >
-    <label
-      aria-labelledby="select-id"
-      class=" css-xs6o3g-label-label"
-      for="select-id"
+    <div
+      class="label-container"
     >
-      Test select input
-    </label>
+      <label
+        aria-labelledby="select-id"
+        class=" css-xs6o3g-label-label"
+        for="select-id"
+      >
+        Test select input
+      </label>
+    </div>
     <div
       class="select-input-wrapper"
       data-testid="custom-react-select"

--- a/src/components/FormElements/Select/styles.ts
+++ b/src/components/FormElements/Select/styles.ts
@@ -38,12 +38,32 @@ export const selectContainer = (
   gap: ${inline ? "1rem" : "0.5rem"};
   align-items: ${inline ? "center" : "normal"};
 
-  label {
-    margin: 0;
+  .label-container {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 0.25rem;
 
-    &.required::after {
-      content: " *";
-      color: ${formElements.generic.required};
+    label {
+      margin: 0;
+
+      &.required::after {
+        content: " *";
+        color: ${formElements.generic.required};
+      }
+    }
+
+    div {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    svg {
+      color: ${formElements.input.infoTooltipColor};
+      &:hover {
+        cursor: help;
+      }
     }
   }
 

--- a/src/components/FormElements/Select/types.ts
+++ b/src/components/FormElements/Select/types.ts
@@ -30,6 +30,7 @@ declare module "react-select/dist/declarations/src/Select" {
     isMulti: IsMulti; // this is required to relieve TS warning
     group?: Group; // this is required to relieve TS warning
     asyncOptions?: AsyncOptions;
+    tooltipContent?: string | JSX.Element;
     type?: SelectType;
     onMenuInputFocus?: () => void;
   }
@@ -55,6 +56,7 @@ export type CustomSelectProps<
   maxWidth?: string;
   creatableTooltip?: string;
   asyncOptions?: AsyncOptions;
+  tooltipContent?: string | JSX.Element;
 };
 
 export type CustomMenuListProps<
@@ -65,6 +67,7 @@ export type CustomMenuListProps<
   innerPlaceholder?: string;
   hasInnerSearch?: boolean;
   asyncOptions?: AsyncOptions;
+  tooltipContent?: string | JSX.Element;
 };
 
 export type CustomValueContainerProps<


### PR DESCRIPTION
## Description

This PR implements the addition of tooltipContent to Select component

## Description

Show info icon next to Select component's label, when the `tooltipContent` attribute is provided
