### PR TITLE
fix: Select component duplicate values and no options message

### DIFF
--- a/src/components/FormElements/Select/Select.stories.tsx
+++ b/src/components/FormElements/Select/Select.stories.tsx
@@ -123,7 +123,14 @@ withValueCreationValidation.args = {
   isClearable: true,
   hasInnerSearch: true,
   type: "creatable",
-  isInputValid: (value: string): boolean => /^(?=.*[^\d])(?=.*\S).+$/.test(value),
+  isInputValid: (value: string): boolean =>
+    /^(?=.*[^\d])(?=.*\S).+$/.test(value) &&
+    !defaultOptions.find((option) => option.label === value),
+  checkIfInputIsSelected: (inputValue: string): string => {
+    return defaultOptions.find((option) => option.label === inputValue)
+      ? "Already selected"
+      : "No options";
+  },
 };
 
 export const AsyncSelect: Story<CustomSelectProps<CustomOption, boolean>> = (args) => {

--- a/src/components/FormElements/Select/Select.tsx
+++ b/src/components/FormElements/Select/Select.tsx
@@ -60,6 +60,7 @@ const Select: ForwardRefRenderFunction<
     tooltipContent = "",
     onChange,
     isInputValid,
+    checkIfInputIsSelected,
     ...rest
   } = props;
   const hasLabel = Boolean(label);
@@ -149,6 +150,7 @@ const Select: ForwardRefRenderFunction<
     },
     onInputChange: (val: string) => setInputValue(val),
     isValidNewOption: isInputValid,
+    noOptionsMessage: () => checkIfInputIsSelected && checkIfInputIsSelected(inputValue),
   };
 
   useClickAway(

--- a/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<Select /> matches snapshot 1`] = `
           </span>
         </span>
         <div
-          class="control-md valid focused css-1stoeuv-control"
+          class="control-md valid focused css-1hos8av-control"
         >
           <div
             class=" css-1fdsijx-ValueContainer"

--- a/src/components/FormElements/Select/styles.ts
+++ b/src/components/FormElements/Select/styles.ts
@@ -207,7 +207,7 @@ export const resolveStyles = (
       boxShadow: "none",
       borderRadius: "5px",
       color: !isDisabled ? base.color : formElements.input.disabledColor,
-      cursor: !isDisabled ? "default" : "not-allowed",
+      cursor: !isDisabled ? "pointer" : "not-allowed",
       pointerEvents: "auto",
 
       "&:hover": {

--- a/src/components/FormElements/Select/types.ts
+++ b/src/components/FormElements/Select/types.ts
@@ -57,6 +57,7 @@ export type CustomSelectProps<
   creatableTooltip?: string;
   asyncOptions?: AsyncOptions;
   isInputValid?: (input: string) => boolean;
+  checkIfInputIsSelected?: (inputValue: string) => string;
   tooltipContent?: string | JSX.Element;
 };
 


### PR DESCRIPTION
## Description

When adding a new valid option we need also to check for duplicates. Also having an option selected should display a message according to that.

## Changes

- Adding a check if a value is valid and not duplicate
- Adding a helper to change the default no options message

