### PR TITLE
refactor(tooltip): remove aria expanded in tooltips

### DIFF
--- a/src/components/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/Chip/__snapshots__/Chip.test.tsx.snap
@@ -19,9 +19,7 @@ exports[`<Chip /> matches snapshot 1`] = `
         />
       </span>
     </button>
-    <div
-      aria-expanded="false"
-    >
+    <div>
       <div
         class="has-overflow"
       >

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -21,6 +21,7 @@ const Tooltip: FC<TooltipProps> = ({
 
   return (
     <Tippy
+      aria={{ expanded: false }}
       placement={placement}
       interactive={interactive}
       appendTo={document.body}


### PR DESCRIPTION
Removed aria-expanded from the tooltip.