### PR TITLE
chore(tooltip): change default value of parentAriaRole

### DIFF
--- a/src/components/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/src/components/Chip/__snapshots__/Chip.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`<Chip /> matches snapshot 1`] = `
     </button>
     <div
       aria-expanded="false"
+      role="tooltip"
     >
       <div
         class="has-overflow"

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -35,7 +35,7 @@ export type TooltipProps = TippyProps & {
 const Tooltip: FC<TooltipProps> = ({
   children,
   content,
-  parentAriaRole,
+  parentAriaRole = "tooltip",
   as = "div",
   placement = "top",
   maxWidth = 350,


### PR DESCRIPTION
Change the parentAriaRole to be "tooltip" as default.