### PR TITLE
chore(tooltip): add parent props for custom props

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -27,15 +27,15 @@ export type TooltipProps = TippyProps & {
     | "figcaption"
     | "form"
     | "fieldset";
-  parentAriaRole?: string;
+  parentProps?: object;
   content: TippyProps["content"];
   maxWidth?: number;
 };
 
 const Tooltip: FC<TooltipProps> = ({
+  parentProps = { role: "tooltip" },
   children,
   content,
-  parentAriaRole = "tooltip",
   as = "div",
   placement = "top",
   maxWidth = 350,
@@ -57,7 +57,7 @@ const Tooltip: FC<TooltipProps> = ({
       )}
       {...rest}
     >
-      <Tag {...(parentAriaRole ? { role: parentAriaRole } : {})}>{children}</Tag>
+      <Tag {...parentProps}>{children}</Tag>
     </Tippy>
   );
 };


### PR DESCRIPTION
Since the props of the tooltip are being spread on the Tippy component. In some cases, we need to pass custom aria roles and properties to the tooltip tag (not tippy). An extra prop that accepts an object for custom props has been added that is spread to the Tag component.