### PR TITLE
chore(status tag): refactor all enums to union types

### DIFF
--- a/src/components/StatusTag/StatusTag.stories.tsx
+++ b/src/components/StatusTag/StatusTag.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StoryFn } from "@storybook/react";
 import { InfoIconSVG } from "../../icons";
-import StatusTag, { StatusTagProps, statusTagSizes } from "./StatusTag";
+import StatusTag, { StatusTagProps } from "./StatusTag";
 
 export default {
   component: StatusTag,
@@ -34,7 +34,7 @@ const Template: StoryFn<StatusTagProps> = (args) => <StatusTag {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
-  size: statusTagSizes.MD,
+  size: "md",
   text: "English",
   icon: InfoIconSVG,
 };
@@ -42,7 +42,7 @@ Default.args = {
 export const WithIcon = Template.bind({});
 
 WithIcon.args = {
-  size: statusTagSizes.MD,
+  size: "md",
   text: "English",
   icon: InfoIconSVG,
 };
@@ -50,7 +50,7 @@ WithIcon.args = {
 export const WithOnlyIcon = Template.bind({});
 
 WithOnlyIcon.args = {
-  size: statusTagSizes.MD,
+  size: "md",
   text: "",
   icon: InfoIconSVG,
 };

--- a/src/components/StatusTag/StatusTag.test.tsx
+++ b/src/components/StatusTag/StatusTag.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { InfoIconSVG as MockIcon } from "../../icons";
-import StatusTag, { statusTagSizes, statusTagColors, StatusTagProps } from "./StatusTag";
+import StatusTag, { StatusTagProps } from "./StatusTag";
 import { render, screen } from "@test-utils/render";
 
 describe("StatusTag component", () => {
@@ -24,16 +24,14 @@ describe("StatusTag component", () => {
   });
 
   it("renders the StatusTag with a custom size and variant", () => {
-    render(
-      <StatusTag {...defaultProps} size={statusTagSizes.SM} color={statusTagColors.POSITIVE} />,
-    );
+    render(<StatusTag {...defaultProps} size="sm" color="positive" />);
     const tagElement = screen.getByTestId("status-tag-Active");
 
     expect(tagElement).toHaveClass("statusTag--sm", "statusTag--positive");
   });
 
   it("renders the StatusTag without text when text is not provided", () => {
-    render(<StatusTag size={statusTagSizes.MD} color={statusTagColors.POSITIVE} />);
+    render(<StatusTag size="md" color="positive" />);
     const tagElement = screen.getByTestId("status-tag-undefined");
     const textElement = tagElement.querySelector(".statusTag__text");
 

--- a/src/components/StatusTag/StatusTag.tsx
+++ b/src/components/StatusTag/StatusTag.tsx
@@ -4,37 +4,32 @@ import { SerializedStyles } from "@emotion/react";
 import { statusTagStyles } from "./styles";
 import { IconType } from "types/common";
 
-export enum statusTagColors {
-  NEUTRAL = "neutral",
-  POSITIVE = "positive",
-  NEGATIVE = "negative",
-  INACTIVE = "inactive",
-  WARNING = "warning",
-  PROMO = "promo",
-  PALE = "pale",
-  GREY = "grey",
-  RED = "red",
-}
-
-export enum statusTagSizes {
-  MD = "md",
-  SM = "sm",
-}
+export type statusTagSizes = "sm" | "md";
+export type statusTagColors =
+  | "neutral"
+  | "positive"
+  | "negative"
+  | "inactive"
+  | "warning"
+  | "promo"
+  | "pale"
+  | "grey"
+  | "red";
 
 export type StatusTagProps = {
   testId?: string;
   text?: string;
   size?: statusTagSizes;
   icon?: IconType;
-  color?: `${statusTagColors}`; // This template literal converts statusTagColors to union types.
+  color?: statusTagColors;
 };
 
 const StatusTag: FC<StatusTagProps> = ({
   testId,
   text,
   icon: Icon,
-  size = statusTagSizes.MD,
-  color = statusTagColors.NEUTRAL,
+  size = "md",
+  color = "neutral",
 }) => {
   const dataTestId = testId ? testId : `status-tag-${text}`;
 

--- a/src/components/StatusTag/styles.ts
+++ b/src/components/StatusTag/styles.ts
@@ -11,12 +11,12 @@ export const statusTagStyles = (
 ) => {
   return css`
     display: inline-flex;
-    height: ${size === statusTagSizes.MD ? "2rem" : "1.25rem"};
-    padding: ${size === statusTagSizes.MD ? "0.5rem" : "0.125rem 0.25rem"};
+    height: ${size === "md" ? "2rem" : "1.25rem"};
+    padding: ${size === "md" ? "0.5rem" : "0.125rem 0.25rem"};
     align-items: center;
-    gap: ${size === statusTagSizes.MD ? "0.625rem" : "0.25rem"};
-    font-size: ${size === statusTagSizes.MD ? typeScaleSizes.sm : typeScaleSizes.xs};
-    font-weight: ${size === statusTagSizes.SM ? "700" : "400"};
+    gap: ${size === "md" ? "0.625rem" : "0.25rem"};
+    font-size: ${size === "md" ? typeScaleSizes.sm : typeScaleSizes.xs};
+    font-weight: ${size === "sm" ? "700" : "400"};
     border-radius: 5px;
     line-height: 1;
 


### PR DESCRIPTION
Change all enums to union types since props needs the actual enum key to associate the values.