### PR TITLE
fix(select): adjust the ratio of label:hint to be 1:1

### DIFF
--- a/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Select /> matches snapshot 1`] = `
 <div>
   <div
-    class="css-1x6a6zi-selectContainer-selectContainer"
+    class="css-zomftj-selectContainer-selectContainer"
   >
     <div
       class="label-container"
@@ -116,7 +116,7 @@ exports[`<Select /> matches snapshot 1`] = `
             <div
               aria-disabled="false"
               aria-selected="false"
-              class="option-md css-1v8sgao-option"
+              class="option-md css-v8hy5y-option"
               id="react-select-3-option-0"
               role="option"
               tabindex="-1"
@@ -140,7 +140,7 @@ exports[`<Select /> matches snapshot 1`] = `
             <div
               aria-disabled="false"
               aria-selected="false"
-              class="option-md css-llutyd-option"
+              class="option-md css-bgeyvp-option"
               id="react-select-3-option-1"
               role="option"
               tabindex="-1"
@@ -164,7 +164,7 @@ exports[`<Select /> matches snapshot 1`] = `
             <div
               aria-disabled="false"
               aria-selected="false"
-              class="option-md css-llutyd-option"
+              class="option-md css-bgeyvp-option"
               id="react-select-3-option-2"
               role="option"
               tabindex="-1"

--- a/src/components/FormElements/Select/styles.ts
+++ b/src/components/FormElements/Select/styles.ts
@@ -280,7 +280,7 @@ export const resolveStyles = ({
       alignItems: "center",
     },
     ".label-text": {
-      flex: 3,
+      flex: 1,
       overflow: "hidden",
       textOverflow: "ellipsis",
     },


### PR DESCRIPTION
## Description

fixes the ratio of label:hint inside the option of the Select
