### PR TITLE
chore(modal.tsx): introduce onAfterOpen prop to Modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -60,13 +60,12 @@ export type Size = "sm" | "md" | "lg" | "fullscreen";
 
 //opacity is set 0.7 default
 
-export type ReactModalProps = Pick<Props, "isOpen"> & {
+export type ReactModalProps = Pick<Props, "isOpen" | "onAfterOpen"> & {
   onClose?: () => void;
   size?: Size;
   rootElementSelector?: string;
   closeOnOutsideClick?: boolean;
   style?: ReactModal.Styles;
-  onAfterOpen?: ReactModal.OnAfterOpenCallback;
 };
 
 const Modal: FCWithChildren<ReactModalProps> & ModalCompoundProps = ({

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -66,6 +66,7 @@ export type ReactModalProps = Pick<Props, "isOpen"> & {
   rootElementSelector?: string;
   closeOnOutsideClick?: boolean;
   style?: ReactModal.Styles;
+  onAfterOpen?: ReactModal.OnAfterOpenCallback;
 };
 
 const Modal: FCWithChildren<ReactModalProps> & ModalCompoundProps = ({
@@ -76,6 +77,7 @@ const Modal: FCWithChildren<ReactModalProps> & ModalCompoundProps = ({
   rootElementSelector = "#app",
   closeOnOutsideClick = true,
   style,
+  onAfterOpen,
 }) => {
   const rootElement = document.querySelector(rootElementSelector) as HTMLElement;
   const clonedChildren = Children.map(children, (child) =>
@@ -91,6 +93,7 @@ const Modal: FCWithChildren<ReactModalProps> & ModalCompoundProps = ({
           isOpen={isOpen}
           appElement={rootElement}
           onRequestClose={onClose}
+          onAfterOpen={onAfterOpen}
           contentLabel="modal"
           overlayClassName={{
             base: "overlay-base",


### PR DESCRIPTION
## Description

This PR introduces `onAfterOpen` prop to `Modal`.

We wanted to focus on a textfield as soon as the modal opens. That's how the need for that came up.

https://github.com/user-attachments/assets/b84a305b-a4cd-4193-9283-808140b7f213

