### PR TITLE
chore(modal.tsx): expose Modal's style prop

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -60,12 +60,11 @@ export type Size = "sm" | "md" | "lg" | "fullscreen";
 
 //opacity is set 0.7 default
 
-export type ReactModalProps = Pick<Props, "isOpen" | "onAfterOpen"> & {
+export type ReactModalProps = Pick<Props, "isOpen" | "onAfterOpen" | "style"> & {
   onClose?: () => void;
   size?: Size;
   rootElementSelector?: string;
   closeOnOutsideClick?: boolean;
-  style?: ReactModal.Styles;
 };
 
 const Modal: FCWithChildren<ReactModalProps> & ModalCompoundProps = ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,3 +54,4 @@ export type { DropdownProps, DropdownItem } from "./components/Dropdown/types";
 export type { TableHandlers } from "./components/Table/types";
 export type { StatusTagColors } from "./components/StatusTag/StatusTag";
 export type { Color } from "./components/Button/Button";
+export type { ReactModalProps as ModalProps } from "./components/Modal/Modal";


### PR DESCRIPTION
## Description

I stumbled on a case where a modal was displayed on top of the sign in modal. To prevent that, I was looking for a way to provide a z-index. `ReactModal` already supports that, I just exposed the `style` prop. 

<img width="586" alt="Screenshot 2025-01-09 at 11 10 49 AM" src="https://github.com/user-attachments/assets/1d617598-7ce8-4268-bf58-ac72261c8f9e" />

Now I can add `style` to `ConfirmationModalProps`
```
export type ConfirmationModalProps = {
  ...
  style?: ModalProps["style"];
  ...
}
```
And provide a lower z-index to my modal
```
<ConfirmationModal 
  // When the session expires, the SignInModal appears with z-index of 9999. 
  // We want our modal to appear below that.
  style={{ overlay: { zIndex: 9998 } }} 
/>
```


