### PR TITLE
chore: prevent immediate toggle func at ToggleSwitch

### DIFF
--- a/src/components/FormElements/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/src/components/FormElements/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useRef, useState } from "react";
 import { StoryFn } from "@storybook/react";
 import { PreviewIconSVG } from "../../../icons";
-import ToggleSwitch, { ToggleProps } from "./ToggleSwitch";
+import Modal from "../../Modal/Modal";
+import Button from "../../Button/Button";
+import ToggleSwitch, { ToggleProps, ToggleSwitchHandlers } from "./ToggleSwitch";
 
 export default {
   title: "components/Form Elements/ToggleSwitch",
@@ -35,4 +37,40 @@ export const WithSubtitle = Template.bind({});
 
 WithSubtitle.args = {
   subtitle: "This is a subtitle for the toggle",
+};
+
+export const WithMiddleStep = () => {
+  const [preventToggle, setPreventToggle] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const toggleSwitchRef = useRef<ToggleSwitchHandlers>(null);
+
+  const handleToggle = (isChecked: boolean): void => {
+    if (!isChecked) {
+      setIsModalOpen(true);
+    } else {
+      setPreventToggle(true);
+    }
+  };
+
+  const handleModalConfirm = (): void => {
+    setPreventToggle(false);
+    setIsModalOpen(false);
+    toggleSwitchRef.current?.toggle();
+  };
+
+  return (
+    <>
+      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+        <Modal.Footer>
+          <Button onClick={handleModalConfirm}>Confirm</Button>
+        </Modal.Footer>
+      </Modal>
+      <ToggleSwitch
+        ref={toggleSwitchRef}
+        onChange={handleToggle}
+        labelBefore="With Middle Step"
+        preventToggle={preventToggle}
+      />
+    </>
+  );
 };

--- a/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useImperativeHandle, forwardRef } from "react";
 import { SerializedStyles } from "@emotion/utils";
 import classNames from "classnames";
 import { Text, Tooltip } from "../../../";
@@ -17,6 +17,7 @@ export type ToggleProps = {
   variant?: "primary" | "success";
   size?: "sm" | "md";
   notSwitchedOff?: boolean;
+  preventToggle?: boolean;
   subtitle?: string;
   hasInlineText?: boolean;
   inlineTextTranslations?: {
@@ -25,7 +26,11 @@ export type ToggleProps = {
   };
   [key: string]: unknown;
   InternalIcon?: JSX.Element;
-  onChange?: () => void;
+  onChange?: (isChecked: boolean) => void;
+};
+
+export type ToggleSwitchHandlers = {
+  toggle: () => void;
 };
 
 const labelClassNames = (
@@ -44,25 +49,29 @@ const switchClassNames = (customClassName: string, isMedium: boolean, isSuccess:
     success: isSuccess,
   });
 
-const ToggleSwitch: React.FC<ToggleProps> = ({
-  id = "toggle-switch",
-  labelBefore,
-  labelAfter,
-  description,
-  defaultChecked = false,
-  isDisabled = false,
-  required = false,
-  hasInlineText = false,
-  inlineTextTranslations = { enabled: "Enabled", disabled: "Disabled" },
-  variant = "primary",
-  notSwitchedOff = false,
-  size = "sm",
-  subtitle = "",
-  tooltip,
-  InternalIcon,
-  onChange,
-  ...rest
-}) => {
+const ToggleSwitch: React.ForwardRefRenderFunction<ToggleSwitchHandlers, ToggleProps> = (
+  {
+    id = "toggle-switch",
+    labelBefore,
+    labelAfter,
+    description,
+    defaultChecked = false,
+    preventToggle = false,
+    isDisabled = false,
+    required = false,
+    hasInlineText = false,
+    inlineTextTranslations = { enabled: "Enabled", disabled: "Disabled" },
+    variant = "primary",
+    notSwitchedOff = false,
+    size = "sm",
+    subtitle = "",
+    tooltip,
+    InternalIcon,
+    onChange,
+    ...rest
+  },
+  ref,
+) => {
   const [isChecked, setIsChecked] = useState(defaultChecked);
   const hasDescription = Boolean(description);
   const hasDescriptionTextWeight = hasDescription ? "700" : "400";
@@ -79,11 +88,16 @@ const ToggleSwitch: React.FC<ToggleProps> = ({
   ): void => {
     e.stopPropagation();
 
-    if (!isDisabled) {
-      setIsChecked((prev) => !prev);
-      if (onChange) onChange();
-    }
+    if (isDisabled) return;
+
+    if (!preventToggle) setIsChecked((prev) => !prev);
+
+    onChange?.(isChecked);
   };
+
+  useImperativeHandle(ref, () => ({
+    toggle: () => setIsChecked((prev) => !prev),
+  }));
 
   return (
     <div
@@ -175,4 +189,4 @@ const ToggleSwitch: React.FC<ToggleProps> = ({
   );
 };
 
-export default ToggleSwitch;
+export default forwardRef(ToggleSwitch);


### PR DESCRIPTION
## Description

Prevent immediate toggle func at ToggleSwitch by adding a `preventToggle` prop to it and a `toggle` func that can be used via imperative handle

## Changes

ex. This PR affects the Course page and components...

## Fixes

ex. This PR resolves #issue1 #issue2
