### PR TITLE
chore(toggle  switch): render aria labelledby conditionally

### DIFF
--- a/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
@@ -152,7 +152,7 @@ const ToggleSwitch: React.ForwardRefRenderFunction<ToggleSwitchHandlers, ToggleP
             onClick={handleToggle}
             role="switch"
             aria-checked={isChecked}
-            aria-labelledby={labelledById}
+            {...(labelledById && { "aria-labelledby": labelledById })}
           >
             {hasInlineText && isMedium && (
               <Text fontSize="sm" className="inline-text">


### PR DESCRIPTION
Render aria-labelledby only if the prop is defined to avoid attribute with undefined value.