### PR TITLE
fix(checkbox): add aria-label

### DIFF
--- a/src/components/FormElements/CheckboxGroup/Checkbox.tsx
+++ b/src/components/FormElements/CheckboxGroup/Checkbox.tsx
@@ -44,7 +44,13 @@ const Checkbox: ForwardRefRenderFunction<HTMLDivElement, CheckboxProps> = (props
       {...containerAttrs}
     >
       {isPartiallySelected && <span data-testid="is-partially-selected" className="dash" />}
-      <input id={id} type="checkbox" readOnly={readOnly} {...rest} />
+      <input
+        id={id}
+        type="checkbox"
+        readOnly={readOnly}
+        aria-label={typeof label === "string" ? label : id}
+        {...rest}
+      />
       <label htmlFor={id} data-testid={`checkbox-label-${id}`}>
         <span className="shadow-element" tabIndex={-1} aria-hidden="true" />
         {label}

--- a/src/components/FormElements/CheckboxGroup/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/FormElements/CheckboxGroup/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<Checkbox /> matches snapshot with \`inline\` = true 1`] = `
     class="css-1uti2s-checkboxContainer-checkboxContainer"
   >
     <input
+      aria-label="Test label"
       id="testId"
       name="testName"
       type="checkbox"
@@ -32,6 +33,7 @@ exports[`<Checkbox /> matches snapshot with \`lg\` size 1`] = `
     class="css-az5b0r-checkboxContainer-checkboxContainer"
   >
     <input
+      aria-label="Test label"
       id="testId"
       name="testName"
       type="checkbox"
@@ -59,6 +61,7 @@ exports[`<Checkbox /> matches snapshot with \`md\` size 1`] = `
     id="my-container-id"
   >
     <input
+      aria-label="Test label"
       class="checkbox"
       id="my-id"
       name="testName"

--- a/src/components/FormElements/CheckboxGroup/__tests__/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/components/FormElements/CheckboxGroup/__tests__/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`<CheckBoxGroup /> matches snapshot 1`] = `
       >
         <input
           aria-checked="false"
+          aria-label="Test groupname"
           id="Test groupname-container"
           name="Test groupname"
           type="checkbox"
@@ -36,6 +37,7 @@ exports[`<CheckBoxGroup /> matches snapshot 1`] = `
           class="css-1uti2s-checkboxContainer-checkboxContainer"
         >
           <input
+            aria-label="Test label"
             id="Test groupname-testValue"
             name="testName"
             type="checkbox"
@@ -71,6 +73,7 @@ exports[`<CheckBoxGroup /> matches snapshot with \`inline = true\` 1`] = `
       >
         <input
           aria-checked="false"
+          aria-label="Test groupname"
           id="Test groupname-container"
           name="Test groupname"
           type="checkbox"
@@ -95,6 +98,7 @@ exports[`<CheckBoxGroup /> matches snapshot with \`inline = true\` 1`] = `
           class="css-1uti2s-checkboxContainer-checkboxContainer"
         >
           <input
+            aria-label="Test label"
             id="Test groupname-testValue"
             name="testName"
             type="checkbox"


### PR DESCRIPTION
This PR adds an aria-label to the Checkbox component to address immediate accessibility concerns.

This change specifically targets issues related to selectable table rows.

While this offers a functional short-term fix, the ideal approach would be to allow the component to accept a prop so developers can provide meaningful, context-specific aria-labels for each use case.

In addition to this, aria-selected and aria-required should also be supported to ensure full accessibility compliance.

This implementation serves as a stopgap, and a more robust, long-term solution should be discussed moving forward.