### PR TITLE
chore(table): add checkbox in DOM order + various fixes

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -35,7 +35,13 @@ export default {
   },
   args: {
     columns: [
-      { accessor: "id", cell: "Code", classNames: ["id"], sortOrder: "asc" },
+      {
+        accessor: "id",
+        cell: "Code",
+        classNames: ["id"],
+        sortOrder: "asc",
+        isDefaultAccessor: true,
+      },
       {
         accessor: "description",
         cell: "Description",

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Table> matches snapshot 1`] = `
 <div>
   <div
-    class="css-1srvkma-tableContainer-tableContainer"
+    class="css-1sh4znl-tableContainer-tableContainer"
     data-testid="table-1"
   >
     <table

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Table> matches snapshot 1`] = `
 <div>
   <div
-    class="css-1sh4znl-tableContainer-tableContainer"
+    class="css-1o541gi-tableContainer-tableContainer"
     data-testid="table-1"
   >
     <table

--- a/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__tests__/__snapshots__/Table.test.tsx.snap
@@ -66,22 +66,27 @@ exports[`<Table> matches snapshot 1`] = `
         >
           <td
             data-testid="header1-cell"
+            id="entry-id1-header1"
             style="max-width: auto;"
           />
           <td
             data-testid="header2-cell"
+            id="entry-id1-header2"
             style="max-width: auto;"
           />
           <td
             data-testid="header3-cell"
+            id="entry-id1-header3"
             style="max-width: auto;"
           />
           <td
             data-testid="header4-cell"
+            id="entry-id1-header4"
             style="max-width: auto;"
           />
           <td
             data-testid="header5-cell"
+            id="entry-id1-header5"
             style="max-width: auto;"
           />
         </tr>
@@ -90,22 +95,27 @@ exports[`<Table> matches snapshot 1`] = `
         >
           <td
             data-testid="header1-cell"
+            id="entry-id2-header1"
             style="max-width: auto;"
           />
           <td
             data-testid="header2-cell"
+            id="entry-id2-header2"
             style="max-width: auto;"
           />
           <td
             data-testid="header3-cell"
+            id="entry-id2-header3"
             style="max-width: auto;"
           />
           <td
             data-testid="header4-cell"
+            id="entry-id2-header4"
             style="max-width: auto;"
           />
           <td
             data-testid="header5-cell"
+            id="entry-id2-header5"
             style="max-width: auto;"
           />
         </tr>
@@ -114,22 +124,27 @@ exports[`<Table> matches snapshot 1`] = `
         >
           <td
             data-testid="header1-cell"
+            id="entry-id3-header1"
             style="max-width: auto;"
           />
           <td
             data-testid="header2-cell"
+            id="entry-id3-header2"
             style="max-width: auto;"
           />
           <td
             data-testid="header3-cell"
+            id="entry-id3-header3"
             style="max-width: auto;"
           />
           <td
             data-testid="header4-cell"
+            id="entry-id3-header4"
             style="max-width: auto;"
           />
           <td
             data-testid="header5-cell"
+            id="entry-id3-header5"
             style="max-width: auto;"
           />
         </tr>
@@ -138,22 +153,27 @@ exports[`<Table> matches snapshot 1`] = `
         >
           <td
             data-testid="header1-cell"
+            id="entry-id4-header1"
             style="max-width: auto;"
           />
           <td
             data-testid="header2-cell"
+            id="entry-id4-header2"
             style="max-width: auto;"
           />
           <td
             data-testid="header3-cell"
+            id="entry-id4-header3"
             style="max-width: auto;"
           />
           <td
             data-testid="header4-cell"
+            id="entry-id4-header4"
             style="max-width: auto;"
           />
           <td
             data-testid="header5-cell"
+            id="entry-id4-header5"
             style="max-width: auto;"
           />
         </tr>

--- a/src/components/Table/components/Body.tsx
+++ b/src/components/Table/components/Body.tsx
@@ -6,7 +6,7 @@ import { ChildrenProps } from "../Table";
 import TableRow from "./TableRow";
 
 const Body: FC<ChildrenProps> = ({
-  id: tableId,
+  id: tableId = "table",
   selectable,
   autohide = false,
   state,

--- a/src/components/Table/components/DataCells.tsx
+++ b/src/components/Table/components/DataCells.tsx
@@ -24,10 +24,12 @@ const DataCells: FC<DataCellsProps> = ({
       {accessors.map((accessor) => {
         const rowObj = row[accessor];
         const { maxWidth } = columns.find((column) => column.accessor === accessor) ?? {};
+        const cellId = `entry-${row.id}-${accessor}`;
 
         return (
           <Cell
-            key={`entry-${row.id}-${accessor}`}
+            key={cellId}
+            id={cellId}
             data-testid={`${accessor}-cell`}
             maxWidth={maxWidth}
             windowWidth={windowWidth}

--- a/src/components/Table/components/Header.tsx
+++ b/src/components/Table/components/Header.tsx
@@ -96,6 +96,7 @@ const Header: FC<ChildrenProps> = ({
             <Checkbox
               id={`select-all-${isSelectAllChecked} - ${id}`}
               name="select-all"
+              aria-label="Select all rows"
               value="all"
               onChange={handleToggleSelectAll}
               checked={isSelectAllChecked}

--- a/src/components/Table/components/Header.tsx
+++ b/src/components/Table/components/Header.tsx
@@ -92,9 +92,8 @@ const Header: FC<ChildrenProps> = ({
     <thead>
       <tr className={rowClassnames(isSelectAllChecked, allRowsSelected, autohide)}>
         {selectable && (
-          <Cell as="td" key={`select-all-${isSelectAllChecked}`} className="selectable-cell">
+          <Cell as="td" className="selectable-cell">
             <Checkbox
-              key={`select-all-${isSelectAllChecked} - ${id}`}
               id={`select-all-${isSelectAllChecked} - ${id}`}
               name="select-all"
               value="all"

--- a/src/components/Table/components/TableRow.tsx
+++ b/src/components/Table/components/TableRow.tsx
@@ -54,14 +54,11 @@ const TableRow: FC<TableRowProps> = ({
     onRowClick && onRowClick(row);
   }, [row.id, disabled]);
 
-  const handleRowSelection = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>): void => {
-      if (disabled) return;
-      e.preventDefault();
-      dispatch({ type: Actions.toggle, payload: row });
-    },
-    [dispatch, disabled],
-  );
+  const handleRowSelection = useCallback((): void => {
+    if (disabled) return;
+
+    dispatch({ type: Actions.toggle, payload: row });
+  }, [dispatch, disabled]);
 
   return (
     <tr
@@ -71,15 +68,13 @@ const TableRow: FC<TableRowProps> = ({
       onMouseLeave={() => !disabled && onHoveredRowChange(null)}
     >
       {selectable && (
-        <Cell
-          key={`${row.id}-${isSelected ? "selected" : "not-selected"}`}
-          className={checkboxWrapperClassnames(Boolean(autohide))}
-        >
+        <Cell key={rowId} className={checkboxWrapperClassnames(Boolean(autohide))}>
           <Checkbox
             id={rowId}
             key={rowId}
             name={rowId}
             value={rowId}
+            tabIndex={0}
             checked={isSelected}
             onChange={handleRowSelection}
             disabled={disabled}

--- a/src/components/Table/components/TableRow.tsx
+++ b/src/components/Table/components/TableRow.tsx
@@ -4,6 +4,7 @@ import { Column, Row } from "../types";
 import Checkbox from "../../FormElements/CheckboxGroup/Checkbox";
 import { Dispatch } from "../reducer";
 import { Actions } from "../constants";
+import { getDefaultAccessor, getVisibleAccessors } from "../helpers";
 import Cell from "./Cell";
 import DataCells from "./DataCells";
 
@@ -47,7 +48,8 @@ const TableRow: FC<TableRowProps> = ({
   onRowClick,
   onHoveredRowChange,
 }) => {
-  const accessors = columns.filter((column) => !column.hidden).map((column) => column.accessor);
+  const accessors = getVisibleAccessors(columns);
+  const defaultAccessor = getDefaultAccessor(columns);
 
   const handleRowClick = useCallback((): void => {
     if (disabled) return;
@@ -78,6 +80,7 @@ const TableRow: FC<TableRowProps> = ({
             checked={isSelected}
             onChange={handleRowSelection}
             disabled={disabled}
+            aria-labelledby={`entry-${row.id}-${defaultAccessor}`}
           />
         </Cell>
       )}

--- a/src/components/Table/components/TableRow.tsx
+++ b/src/components/Table/components/TableRow.tsx
@@ -76,7 +76,6 @@ const TableRow: FC<TableRowProps> = ({
             key={rowId}
             name={rowId}
             value={rowId}
-            tabIndex={0}
             checked={isSelected}
             onChange={handleRowSelection}
             disabled={disabled}

--- a/src/components/Table/helpers.ts
+++ b/src/components/Table/helpers.ts
@@ -1,0 +1,10 @@
+import { Column } from "./types";
+
+export const getVisibleAccessors = (columns: Column[]): string[] => {
+  return columns.filter((column) => !column.hidden).map((column) => column.accessor);
+};
+
+export const getDefaultAccessor = (columns: Column[]): string | undefined => {
+  const visibleAccessors = getVisibleAccessors(columns);
+  return columns.find((column) => column.isDefaultAccessor)?.accessor ?? visibleAccessors[0];
+};

--- a/src/components/Table/styles.ts
+++ b/src/components/Table/styles.ts
@@ -25,23 +25,6 @@ export const tableContainer = ({ table }: Theme) => css`
         height: 54px;
         white-space: nowrap;
 
-        &.autohide-cell:hover,
-        &.selected {
-          .selectable-cell {
-            > div {
-              visibility: visible !important;
-            }
-          }
-        }
-
-        &.autohide-cell {
-          .selectable-cell {
-            > div {
-              visibility: hidden;
-            }
-          }
-        }
-
         th,
         td {
           font-weight: 700;
@@ -108,18 +91,30 @@ export const tableContainer = ({ table }: Theme) => css`
           background-color: ${table.rowHoverColor};
         }
 
+        .selectable-cell:focus-within {
+          > div {
+            opacity: 1;
+          }
+        }
+
         &:hover,
         &.selected {
           .autohide-cell {
             > div {
-              display: flex;
+              opacity: 1;
             }
+          }
+        }
+
+        .autohide-cell:focus-within {
+          > div {
+            opacity: 1;
           }
         }
 
         .autohide-cell {
           > div {
-            display: none;
+            opacity: 0;
           }
         }
 

--- a/src/components/Table/styles.ts
+++ b/src/components/Table/styles.ts
@@ -91,12 +91,6 @@ export const tableContainer = ({ table }: Theme) => css`
           background-color: ${table.rowHoverColor};
         }
 
-        .selectable-cell:focus-within {
-          > div {
-            opacity: 1;
-          }
-        }
-
         &:hover,
         &.selected {
           .autohide-cell {

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -5,6 +5,7 @@ import { IconType } from "types/common";
 export type Column = {
   accessor: string;
   isDefaultSort?: boolean;
+  isDefaultAccessor?: boolean;
   cell: string | ((arg?: unknown) => JSX.Element | null);
   hidden?: boolean;
   classNames?: string[];


### PR DESCRIPTION
[Task](https://app.asana.com/0/1202996243430204/1209871601806447/f)

In this PR:
- We make all table checkboxes available in the DOM for accessibility reasons (interaction).
- Fix undefined id values by defaulting table id to "table".
- Removed some cell keys that caused unnecessary cell re-rendering and de-focus of checkbox selections.
- Added the ability to specify a default accessor for labelledby checkbox reference.