### PR TITLE
fix(select): increase z-index at selects with portaling enabled

### DIFF
--- a/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Select /> matches snapshot 1`] = `
 <div>
   <div
-    class="css-zomftj-selectContainer-selectContainer"
+    class="css-is68w0-selectContainer-selectContainer"
   >
     <div
       class="label-container"

--- a/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/FormElements/Select/__snapshots__/Select.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Select /> matches snapshot 1`] = `
 <div>
   <div
-    class="css-is68w0-selectContainer-selectContainer"
+    class="css-53vxw-selectContainer-selectContainer"
   >
     <div
       class="label-container"

--- a/src/components/FormElements/Select/styles.ts
+++ b/src/components/FormElements/Select/styles.ts
@@ -119,7 +119,7 @@ export const resolveStyles = ({
   size,
   menuMaxWidth,
 }: {
-  size: string;
+  size: InputSize;
   menuMaxWidth?: number;
 }): StylesConfig<CustomOption> => ({
   menu: (base: CSSObjectWithLabel) => {
@@ -137,6 +137,9 @@ export const resolveStyles = ({
       ...menuMaxWidthStyles,
     };
   },
+  // Modal overlays use a z-index of 9998
+  // To ensure the menu appears on top, set its z-index to at least 9999
+  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
   placeholder: (
     base: CSSObjectWithLabel,
     { isDisabled }: PlaceholderProps<CustomOption, boolean, GroupBase<CustomOption>>,

--- a/src/components/FormElements/Select/styles.ts
+++ b/src/components/FormElements/Select/styles.ts
@@ -15,6 +15,8 @@ import { inputHeight } from "../styles";
 import { CustomOption } from "./types";
 import { formElements, scrollbar } from "@theme/default/config";
 
+const portalSelectZIndex = 9999;
+
 export const selectContainer = (
   { formElements }: Theme,
   {
@@ -139,7 +141,7 @@ export const resolveStyles = ({
   },
   // Modal overlays use a z-index of 9998
   // To ensure the menu appears on top, set its z-index to at least 9999
-  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+  menuPortal: (base) => ({ ...base, zIndex: portalSelectZIndex }),
   placeholder: (
     base: CSSObjectWithLabel,
     { isDisabled }: PlaceholderProps<CustomOption, boolean, GroupBase<CustomOption>>,

--- a/src/components/FormElements/Select/types.ts
+++ b/src/components/FormElements/Select/types.ts
@@ -1,4 +1,5 @@
 import type { GroupBase, Props } from "react-select";
+import { InputSize } from "../Input/Input";
 
 export type Status = "valid" | "error";
 
@@ -25,7 +26,7 @@ export type CustomSelectProps<
   type?: SelectType;
   required?: boolean;
   label?: string;
-  size?: "sm" | "md" | "lg";
+  size?: InputSize;
   inline?: boolean;
   status?: "valid" | "error";
   isInlineFlex?: boolean;


### PR DESCRIPTION
## Description

The menu of the modals is hidden behind the overlay. Thus, we need to increase z-index



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209821642847818