### PR TITLE
Add outline option for toggle switch

### DIFF
--- a/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
@@ -16,7 +16,7 @@ type ToggleSpecificProps = {
   required?: boolean;
   tooltip?: string;
   variant?: "primary" | "success";
-  shouldOutline?: boolean;
+  showOutlineBorder?: boolean;
   size?: "sm" | "md";
   notSwitchedOff?: boolean;
   preventToggle?: boolean;
@@ -68,7 +68,7 @@ const ToggleSwitch: React.ForwardRefRenderFunction<ToggleSwitchHandlers, ToggleP
     hasInlineText = false,
     inlineTextTranslations = { enabled: "Enabled", disabled: "Disabled" },
     variant = "primary",
-    shouldOutline = false,
+    showOutlineBorder = false,
     notSwitchedOff = false,
     size = "sm",
     subtitle = "",
@@ -117,7 +117,7 @@ const ToggleSwitch: React.ForwardRefRenderFunction<ToggleSwitchHandlers, ToggleP
           isDisabled,
           hasDescription,
           notSwitchedOff,
-          shouldOutline,
+          showOutlineBorder,
         })
       }
       data-testid={id}

--- a/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
@@ -117,7 +117,7 @@ const ToggleSwitch: React.ForwardRefRenderFunction<ToggleSwitchHandlers, ToggleP
           isDisabled,
           hasDescription,
           notSwitchedOff,
-          shouldOutline
+          shouldOutline,
         })
       }
       data-testid={id}

--- a/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
@@ -68,7 +68,7 @@ const ToggleSwitch: React.ForwardRefRenderFunction<ToggleSwitchHandlers, ToggleP
     hasInlineText = false,
     inlineTextTranslations = { enabled: "Enabled", disabled: "Disabled" },
     variant = "primary",
-    shouldOutline = true,
+    shouldOutline = false,
     notSwitchedOff = false,
     size = "sm",
     subtitle = "",

--- a/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/FormElements/ToggleSwitch/ToggleSwitch.tsx
@@ -16,6 +16,7 @@ type ToggleSpecificProps = {
   required?: boolean;
   tooltip?: string;
   variant?: "primary" | "success";
+  shouldOutline?: boolean;
   size?: "sm" | "md";
   notSwitchedOff?: boolean;
   preventToggle?: boolean;
@@ -67,6 +68,7 @@ const ToggleSwitch: React.ForwardRefRenderFunction<ToggleSwitchHandlers, ToggleP
     hasInlineText = false,
     inlineTextTranslations = { enabled: "Enabled", disabled: "Disabled" },
     variant = "primary",
+    shouldOutline = true,
     notSwitchedOff = false,
     size = "sm",
     subtitle = "",
@@ -115,6 +117,7 @@ const ToggleSwitch: React.ForwardRefRenderFunction<ToggleSwitchHandlers, ToggleP
           isDisabled,
           hasDescription,
           notSwitchedOff,
+          shouldOutline
         })
       }
       data-testid={id}

--- a/src/components/FormElements/ToggleSwitch/__tests__/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/src/components/FormElements/ToggleSwitch/__tests__/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ToggleSwitch /> Matches snapshot 1`] = `
 <div>
   <div
-    class="css-m7865s-ToggleContainer-ToggleContainer"
+    class="css-jpnwjc-ToggleContainer-ToggleContainer"
     data-checked="false"
     data-testid="my-toggle"
     id="my-toggle"

--- a/src/components/FormElements/ToggleSwitch/__tests__/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/src/components/FormElements/ToggleSwitch/__tests__/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ToggleSwitch /> Matches snapshot 1`] = `
 <div>
   <div
-    class="css-1clwnwy-ToggleContainer-ToggleContainer"
+    class="css-m7865s-ToggleContainer-ToggleContainer"
     data-checked="false"
     data-testid="my-toggle"
     id="my-toggle"

--- a/src/components/FormElements/ToggleSwitch/__tests__/__snapshots__/ToggleSwitch.test.tsx.snap
+++ b/src/components/FormElements/ToggleSwitch/__tests__/__snapshots__/ToggleSwitch.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<ToggleSwitch /> Matches snapshot 1`] = `
 <div>
   <div
-    class="css-v27xm3-ToggleContainer-ToggleContainer"
+    class="css-1clwnwy-ToggleContainer-ToggleContainer"
     data-checked="false"
     data-testid="my-toggle"
     id="my-toggle"

--- a/src/components/FormElements/ToggleSwitch/styles.ts
+++ b/src/components/FormElements/ToggleSwitch/styles.ts
@@ -35,7 +35,6 @@ export const ToggleContainer = (
       `
         border: 1px solid ${formElements.toggleSwitch.textColor};
         border-radius: 0.625rem;
-        border-color: ${formElements.toggleSwitch.textColor};
       `}
 
       .switch {

--- a/src/components/FormElements/ToggleSwitch/styles.ts
+++ b/src/components/FormElements/ToggleSwitch/styles.ts
@@ -7,13 +7,13 @@ export const ToggleContainer = (
     isDisabled,
     hasDescription,
     notSwitchedOff,
-    shouldOutline,
+    showOutlineBorder,
   }: {
     isChecked: boolean;
     isDisabled: boolean;
     hasDescription: boolean;
     notSwitchedOff: boolean;
-    shouldOutline: boolean;
+    showOutlineBorder: boolean;
   },
 ): SerializedStyles => css`
   display: flex;
@@ -31,10 +31,10 @@ export const ToggleContainer = (
     .switch-container {
       display: flex;
 
-      ${shouldOutline &&
+      ${showOutlineBorder &&
       `
         border: 1px solid ${formElements.toggleSwitch.textColor};
-        border-radius: 10px;
+        border-radius: 0.625px;
         border-color: ${formElements.toggleSwitch.textColor};
       `}
 

--- a/src/components/FormElements/ToggleSwitch/styles.ts
+++ b/src/components/FormElements/ToggleSwitch/styles.ts
@@ -7,8 +7,14 @@ export const ToggleContainer = (
     isDisabled,
     hasDescription,
     notSwitchedOff,
-    shouldOutline
-  }: { isChecked: boolean; isDisabled: boolean; hasDescription: boolean; notSwitchedOff: boolean, shouldOutline: boolean },
+    shouldOutline,
+  }: {
+    isChecked: boolean;
+    isDisabled: boolean;
+    hasDescription: boolean;
+    notSwitchedOff: boolean;
+    shouldOutline: boolean;
+  },
 ): SerializedStyles => css`
   display: flex;
   flex-direction: column;

--- a/src/components/FormElements/ToggleSwitch/styles.ts
+++ b/src/components/FormElements/ToggleSwitch/styles.ts
@@ -7,7 +7,8 @@ export const ToggleContainer = (
     isDisabled,
     hasDescription,
     notSwitchedOff,
-  }: { isChecked: boolean; isDisabled: boolean; hasDescription: boolean; notSwitchedOff: boolean },
+    shouldOutline
+  }: { isChecked: boolean; isDisabled: boolean; hasDescription: boolean; notSwitchedOff: boolean, shouldOutline: boolean },
 ): SerializedStyles => css`
   display: flex;
   flex-direction: column;
@@ -23,6 +24,13 @@ export const ToggleContainer = (
 
     .switch-container {
       display: flex;
+
+      ${shouldOutline &&
+      `
+        border: 1px solid ${formElements.toggleSwitch.textColor};
+        border-radius: 10px;
+        border-color: ${formElements.toggleSwitch.textColor};
+      `}
 
       .switch {
         position: relative;

--- a/src/components/FormElements/ToggleSwitch/styles.ts
+++ b/src/components/FormElements/ToggleSwitch/styles.ts
@@ -34,7 +34,7 @@ export const ToggleContainer = (
       ${showOutlineBorder &&
       `
         border: 1px solid ${formElements.toggleSwitch.textColor};
-        border-radius: 0.625px;
+        border-radius: 0.625rem;
         border-color: ${formElements.toggleSwitch.textColor};
       `}
 


### PR DESCRIPTION
This pull request introduces a new `shouldOutline` property to the `ToggleSwitch` component, allowing developers to optionally add an outline to the toggle switch. The changes involve updates to the component's props, default values, and styles to support this new feature.