### PR TITLE
chore(dropdown): add divider to organize list items

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -17,7 +17,11 @@ const dropdownList: DropdownItem[] = [
         label: "Category 3",
         items: [
           { label: "Option 5", value: "5" },
-          { label: "Option 6", value: "6", isDisabled: true },
+          { label: "Option 6", value: "6", isDisabled: true, divider: true },
+          { label: "Option 7", value: "7" },
+          { label: "Option 8", value: "8", divider: true },
+          { label: "Option 9", value: "9" },
+          { label: "Option 10", value: "10" },
         ],
       },
     ],

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -53,6 +53,46 @@ it("disabled dropdown does not call onToggleList when clicked", () => {
   expect(mockOnToggleList).not.toHaveBeenCalled();
 });
 
+it("disabled dropdown item does not call onListItemSelect when clicked", () => {
+  const mockOnListItemSelect = jest.fn();
+  const listWithDisabledItem: DropdownItem[] = [
+    { label: "Option 1", value: "1" },
+    { label: "Option 2", value: "2", isDisabled: true },
+    { label: "Option 3", value: "3" },
+  ];
+
+  const { getByText } = render(
+    <Dropdown list={listWithDisabledItem} onListItemSelect={mockOnListItemSelect}>
+      <Button color="primary">Toggle</Button>
+    </Dropdown>,
+  );
+
+  fireEvent.click(getByText("Toggle"));
+  fireEvent.click(getByText("Option 2"));
+
+  expect(mockOnListItemSelect).not.toHaveBeenCalled();
+});
+
+it("dropdown item with divider has correct CSS class", () => {
+  const listWithDividerItem: DropdownItem[] = [
+    { label: "Option 1", value: "1" },
+    { label: "Option 2", value: "2", divider: true },
+    { label: "Option 3", value: "3" },
+  ];
+
+  const { getByText, container } = render(
+    <Dropdown list={listWithDividerItem}>
+      <Button color="primary">Toggle</Button>
+    </Dropdown>,
+  );
+
+  fireEvent.click(getByText("Toggle"));
+
+  const dividerItem = container.querySelector(".separator");
+  expect(dividerItem).toBeInTheDocument();
+  expect(dividerItem).toHaveClass("separator");
+});
+
 const mockList: DropdownItem[] = [
   {
     label: "Category 1",

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -73,7 +73,7 @@ it("disabled dropdown item does not call onListItemSelect when clicked", () => {
   expect(mockOnListItemSelect).not.toHaveBeenCalled();
 });
 
-it("dropdown item with divider has correct CSS class", () => {
+it("dropdown item with divider renders divider element", () => {
   const listWithDividerItem: DropdownItem[] = [
     { label: "Option 1", value: "1" },
     { label: "Option 2", value: "2", divider: true },
@@ -88,9 +88,9 @@ it("dropdown item with divider has correct CSS class", () => {
 
   fireEvent.click(getByText("Toggle"));
 
-  const dividerItem = container.querySelector(".separator");
-  expect(dividerItem).toBeInTheDocument();
-  expect(dividerItem).toHaveClass("separator");
+  const dividerElement = container.querySelector(".divider");
+  expect(dividerElement).toBeInTheDocument();
+  expect(dividerElement).toHaveClass("divider");
 });
 
 const mockList: DropdownItem[] = [

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -255,7 +255,7 @@ const Dropdown: FC<DropdownProps> = ({
   // List item methods
 
   const handleOnClickListItem = (item: DropdownItem): void => {
-    if (isListOpen && !disabled) {
+    if (isListOpen && !disabled && !item.isDisabled) {
       onListItemSelect && onListItemSelect(item);
       !remainOpenOnSelect && setIsListOpen(false);
     }

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
       >
         <li
           aria-disabled="true"
-          class="css-egbxdj-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
+          class="css-asc0ym-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
           tabindex="-1"
         >
           <span
@@ -40,7 +40,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </span>
         </li>
         <li
-          class="1 dropdown-list-item css-wjci8h-DropdownListItemStyles-DropdownListItemStyles"
+          class="1 dropdown-list-item css-jnnfjg-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -59,7 +59,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
         </li>
         <li
           aria-disabled="true"
-          class="css-1t4ta5l-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
+          class="css-ium8yb-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
           tabindex="-1"
         >
           <span
@@ -71,7 +71,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </span>
         </li>
         <li
-          class="2 dropdown-list-item css-cc13u6-DropdownListItemStyles-DropdownListItemStyles"
+          class="2 dropdown-list-item css-15w1wdv-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -89,7 +89,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </div>
         </li>
         <li
-          class="3 dropdown-list-item css-cc13u6-DropdownListItemStyles-DropdownListItemStyles"
+          class="3 dropdown-list-item css-15w1wdv-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -108,7 +108,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
         </li>
         <li
           aria-disabled="true"
-          class="css-egbxdj-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
+          class="css-asc0ym-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
           tabindex="-1"
         >
           <span
@@ -120,7 +120,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </span>
         </li>
         <li
-          class="15 dropdown-list-item css-wjci8h-DropdownListItemStyles-DropdownListItemStyles"
+          class="15 dropdown-list-item css-jnnfjg-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -138,7 +138,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </div>
         </li>
         <li
-          class="16 dropdown-list-item css-wjci8h-DropdownListItemStyles-DropdownListItemStyles"
+          class="16 dropdown-list-item css-jnnfjg-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -156,7 +156,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </div>
         </li>
         <li
-          class="5 dropdown-list-item css-1xoir1j-DropdownListItemStyles-DropdownListItemStyles"
+          class="5 dropdown-list-item css-l3v8v0-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
 <div>
   <div
-    class="dropdown css-1t3sq90-DropdownContainer-DropdownContainer"
+    class="dropdown css-bfrzd1-DropdownContainer-DropdownContainer"
     tabindex="0"
   >
     <div
@@ -23,12 +23,12 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
       class="dropdown-wrapper bottom-start"
     >
       <ul
-        class="dropdown-list css-1bjplf2-DropdownList-DropdownList"
+        class="dropdown-list css-n6ff20-DropdownList-DropdownList"
         role="list"
       >
         <li
           aria-disabled="true"
-          class="css-asc0ym-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
+          class="css-egbxdj-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
           tabindex="-1"
         >
           <span
@@ -40,7 +40,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </span>
         </li>
         <li
-          class="1 dropdown-list-item css-jnnfjg-DropdownListItemStyles-DropdownListItemStyles"
+          class="1 dropdown-list-item css-wjci8h-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -59,7 +59,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
         </li>
         <li
           aria-disabled="true"
-          class="css-ium8yb-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
+          class="css-1t4ta5l-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
           tabindex="-1"
         >
           <span
@@ -71,7 +71,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </span>
         </li>
         <li
-          class="2 dropdown-list-item css-15w1wdv-DropdownListItemStyles-DropdownListItemStyles"
+          class="2 dropdown-list-item css-cc13u6-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -89,7 +89,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </div>
         </li>
         <li
-          class="3 dropdown-list-item css-15w1wdv-DropdownListItemStyles-DropdownListItemStyles"
+          class="3 dropdown-list-item css-cc13u6-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -108,7 +108,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
         </li>
         <li
           aria-disabled="true"
-          class="css-asc0ym-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
+          class="css-egbxdj-DropdownListItemTitleStyles-DropdownListItemTitleStyles"
           tabindex="-1"
         >
           <span
@@ -120,7 +120,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </span>
         </li>
         <li
-          class="15 dropdown-list-item css-jnnfjg-DropdownListItemStyles-DropdownListItemStyles"
+          class="15 dropdown-list-item css-wjci8h-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -138,7 +138,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </div>
         </li>
         <li
-          class="16 dropdown-list-item css-jnnfjg-DropdownListItemStyles-DropdownListItemStyles"
+          class="16 dropdown-list-item css-wjci8h-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div
@@ -156,7 +156,7 @@ exports[`<Dropdown /> opens the dropdown and matches snapshot 1`] = `
           </div>
         </li>
         <li
-          class="5 dropdown-list-item css-l3v8v0-DropdownListItemStyles-DropdownListItemStyles"
+          class="5 dropdown-list-item css-1xoir1j-DropdownListItemStyles-DropdownListItemStyles"
           tabindex="0"
         >
           <div

--- a/src/components/Dropdown/components/DropdownListItem.tsx
+++ b/src/components/Dropdown/components/DropdownListItem.tsx
@@ -10,13 +10,11 @@ import { TypographyLevels } from "@theme/utils/typography";
 const dropdownItemClasses = (
   value: DropdownItem["value"],
   className: DropdownItem["className"],
-  divider: DropdownItem["divider"],
 ): string =>
   classNames({
     "dropdown-list-item": true,
     [`${value}`]: true,
     [`${className}`]: Boolean(className),
-    separator: Boolean(divider),
   });
 
 type DropdownListItemProps = {
@@ -80,18 +78,21 @@ const DropdownListItem: FC<DropdownListItemProps> = ({
   );
 
   return (
-    <li
-      className={dropdownItemClasses(value, className, divider)}
-      tabIndex={0}
-      data-testid={id}
-      css={(theme): SerializedStyles =>
-        DropdownListItemStyles(theme, { isSearchable, level, isDisabled })
-      }
-      onClick={handleOnClickListItem}
-      onKeyDown={handleOnKeyDownListItem}
-    >
-      {tooltipElement}
-    </li>
+    <>
+      <li
+        className={dropdownItemClasses(value, className)}
+        tabIndex={0}
+        data-testid={id}
+        css={(theme): SerializedStyles =>
+          DropdownListItemStyles(theme, { isSearchable, level, isDisabled })
+        }
+        onClick={handleOnClickListItem}
+        onKeyDown={handleOnKeyDownListItem}
+      >
+        {tooltipElement}
+      </li>
+      {divider && <div className="divider" />}
+    </>
   );
 };
 

--- a/src/components/Dropdown/components/DropdownListItem.tsx
+++ b/src/components/Dropdown/components/DropdownListItem.tsx
@@ -10,11 +10,13 @@ import { TypographyLevels } from "@theme/utils/typography";
 const dropdownItemClasses = (
   value: DropdownItem["value"],
   className: DropdownItem["className"],
+  divider: DropdownItem["divider"],
 ): string =>
   classNames({
     "dropdown-list-item": true,
     [`${value}`]: true,
     [`${className}`]: Boolean(className),
+    separator: Boolean(divider),
   });
 
 type DropdownListItemProps = {
@@ -36,7 +38,16 @@ const DropdownListItem: FC<DropdownListItemProps> = ({
   onClick,
   onKeyDown,
 }) => {
-  const { id, isDisabled = false, label, icon, value, tooltipContent, className } = item;
+  const {
+    id,
+    label,
+    icon,
+    value,
+    tooltipContent,
+    className,
+    isDisabled = false,
+    divider = false,
+  } = item;
 
   const handleOnClickListItem = (e: MouseEvent<HTMLLIElement>): void => {
     e.stopPropagation();
@@ -70,7 +81,7 @@ const DropdownListItem: FC<DropdownListItemProps> = ({
 
   return (
     <li
-      className={dropdownItemClasses(value, className)}
+      className={dropdownItemClasses(value, className, divider)}
       tabIndex={0}
       data-testid={id}
       css={(theme): SerializedStyles =>

--- a/src/components/Dropdown/components/styles.ts
+++ b/src/components/Dropdown/components/styles.ts
@@ -26,8 +26,6 @@ export const DropdownListItemStyles = (
 
   &.separator {
     border-bottom: 1px solid ${dropdown.borderBottomColor};
-    padding-block: 0;
-    margin-block: 0.25rem;
   }
 
   span {

--- a/src/components/Dropdown/components/styles.ts
+++ b/src/components/Dropdown/components/styles.ts
@@ -26,6 +26,8 @@ export const DropdownListItemStyles = (
 
   &.separator {
     border-bottom: 1px solid ${dropdown.borderBottomColor};
+    padding-block: 0;
+    margin-block: 0.25rem;
   }
 
   span {

--- a/src/components/Dropdown/styles.ts
+++ b/src/components/Dropdown/styles.ts
@@ -94,4 +94,10 @@ export const DropdownList = (
     align-items: center;
     height: 2rem;
   }
+
+  .divider {
+    height: 1px;
+    border-bottom: 1px solid ${dropdown.borderBottomColor};
+    margin-block: 0.25rem;
+  }
 `;

--- a/src/components/Dropdown/types.ts
+++ b/src/components/Dropdown/types.ts
@@ -13,6 +13,7 @@ export type DropdownItem = {
   category?: string;
   isDisabled?: boolean;
   tooltipContent?: TippyProps["content"];
+  divider?: boolean;
 };
 
 export type DropdownProps = HTMLAttributes<HTMLDivElement> & {


### PR DESCRIPTION
## Description

This PR adds a divider element to the `Dropdown` component to improve the visual organization of options. This creates a clear visual separation between groups of items using consistent styling, making dropdowns easier to scan and navigate.

## Changes

- Introduced a divider element rendered as a `div` with divider class and styles.
- Ensured disabled items remain unselectable.
- Updated component documentation and examples to demonstrate the divider usage.
