### PR TITLE
Fix: align icon green colors

### DIFF
--- a/src/icons/legacy/unit-not-selected.svg
+++ b/src/icons/legacy/unit-not-selected.svg
@@ -1,4 +1,4 @@
 <svg id="Unit-Completion_Element" data-name="Unit-Completion Element" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect id="Rectangle_8255" data-name="Rectangle 8255" width="32" height="32" fill="none"/>
-  <circle id="Ellipse_302" data-name="Ellipse 302" cx="10" cy="10" r="10" transform="translate(6 6)" fill="#3cb744"/>
+  <circle id="Ellipse_302" data-name="Ellipse 302" cx="10" cy="10" r="10" transform="translate(6 6)" fill="#1B7855"/>
 </svg>


### PR DESCRIPTION
## Description

Updates the fill color of unit-not-selected.svg from #3cb744 to #1B7855 for visual consistency with the rest of the icon set.

## Changes

src/icons/legacy/unit-not-selected.svg

