### PR TITLE
chore(button): pass props to iconBefore and iconAfter

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -163,10 +163,38 @@ WithIconBefore.args = {
   children: "Icon prefix",
 };
 
+export const WithIconBeforeWithProps = Template.bind({});
+
+WithIconBeforeWithProps.args = {
+  color: "primary",
+  iconBefore: CalendarSVG,
+  iconBeforeProps: {
+    "aria-hidden": "true",
+    focusable: "false",
+    className: "custom-icon",
+    height: 20,
+  },
+  children: "Icon prefix",
+};
+
 export const WithIconAfter = Template.bind({});
 
 WithIconAfter.args = {
   color: "primary",
   iconAfter: CalendarSVG,
+  children: "Icon prefix",
+};
+
+export const WithIconAfterWithProps = Template.bind({});
+
+WithIconAfterWithProps.args = {
+  color: "primary",
+  iconAfter: CalendarSVG,
+  iconAfterProps: {
+    "aria-hidden": "true",
+    focusable: "false",
+    className: "custom-icon",
+    height: 20,
+  },
   children: "Icon prefix",
 };

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,9 +1,12 @@
-import React from "react";
+import React, { SVGProps } from "react";
 import userEvent from "@testing-library/user-event";
 import { faker } from "@faker-js/faker";
 import { CalendarSVG } from "../../icons/";
 import Button from "./Button";
 import { render, screen } from "@test-utils/render";
+
+/** Jest replaces `.svg` with a string stub; use a real SVG component to assert `className` merging. */
+const MockSvgIcon = (props: SVGProps<SVGSVGElement>): JSX.Element => <svg {...props} />;
 
 describe("<Button />", () => {
   it("renders correctly!", () => {
@@ -88,7 +91,39 @@ describe("<Button />", () => {
     render(<Button iconAfter={CalendarSVG}>With suffix icon</Button>);
 
     const icon = screen.getByTestId("suffix-icon");
+
     expect(icon).toBeInTheDocument();
+  });
+
+  it("with prefix icon with props", () => {
+    render(
+      <Button
+        iconBefore={MockSvgIcon}
+        iconBeforeProps={{ "aria-hidden": true, className: "custom-icon" }}
+      >
+        Save
+      </Button>,
+    );
+    const icon = screen.getByTestId("prefix-icon");
+
+    expect(icon).toHaveAttribute("aria-hidden", "true");
+    expect(icon).toHaveClass("icon", "custom-icon");
+  });
+
+  it("with suffix icon with props", () => {
+    render(
+      <Button
+        iconAfter={MockSvgIcon}
+        iconAfterProps={{ "aria-hidden": true, className: "custom-icon" }}
+      >
+        Save
+      </Button>,
+    );
+
+    const icon = screen.getByTestId("suffix-icon");
+
+    expect(icon).toHaveClass("icon", "custom-icon");
+    expect(icon).toHaveAttribute("aria-hidden", "true");
   });
 
   it("matches snapshot", () => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, ElementType } from "react";
+import React, { ReactElement, ReactNode, ElementType, SVGProps } from "react";
 import { SerializedStyles } from "@emotion/react";
 import { LazyMotion, domAnimation, m, AnimatePresence } from "framer-motion";
 import classNames from "classnames";
@@ -26,7 +26,9 @@ export type Props = {
   block?: boolean;
   isLoading?: boolean;
   iconBefore?: IconType;
+  iconBeforeProps?: SVGProps<SVGSVGElement>;
   iconAfter?: IconType;
+  iconAfterProps?: SVGProps<SVGSVGElement>;
   className?: string;
   disabled?: boolean;
   rounded?: boolean;
@@ -50,7 +52,9 @@ const Button = <C extends ElementType = "button">(props: ButtonProps<C>): ReactE
     className = "",
     rounded = false,
     iconBefore,
+    iconBeforeProps,
     iconAfter,
+    iconAfterProps,
     children,
     disabled,
     underlined,
@@ -75,6 +79,20 @@ const Button = <C extends ElementType = "button">(props: ButtonProps<C>): ReactE
     active: active,
   });
 
+  const iconBeforePropsWithDefaults = {
+    ...iconBeforeProps,
+    height: iconBeforeProps?.height ?? iconSizes[size],
+    className: classNames("icon", iconBeforeProps?.className),
+    "data-testid": "prefix-icon",
+  };
+
+  const iconAfterPropsWithDefaults = {
+    ...iconAfterProps,
+    height: iconAfterProps?.height ?? iconSizes[size],
+    className: classNames("icon", iconAfterProps?.className),
+    "data-testid": "suffix-icon",
+  };
+
   return (
     <LazyMotion features={domAnimation}>
       <Component
@@ -98,13 +116,9 @@ const Button = <C extends ElementType = "button">(props: ButtonProps<C>): ReactE
             </m.div>
           )}
         </AnimatePresence>
-        {PrefixIcon && (
-          <PrefixIcon height={iconSizes[size]} className="icon" data-testid="prefix-icon" />
-        )}
+        {PrefixIcon && <PrefixIcon {...iconBeforePropsWithDefaults} />}
         <span className="btn-text">{children}</span>
-        {SuffixIcon && (
-          <SuffixIcon height={iconSizes[size]} className="icon" data-testid="suffix-icon" />
-        )}
+        {SuffixIcon && <SuffixIcon {...iconAfterPropsWithDefaults} />}
       </Component>
     </LazyMotion>
   );


### PR DESCRIPTION
## Description

This PR implements allows to pass props on the `Button` component before and after icons

## Changes

This PR introduces the `iconBeforeProps` and `iconAfterProps` props to `Button` component
