### PR TITLE
fix(Drawer): prevent nested drawer mask stacking

### DIFF
--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -32,11 +32,11 @@ export default {
   ],
 };
 
-type DrawerArgs = Pick<DrawerProps, "placement" | "showMask"> & {
+type DrawerArgs = Pick<DrawerProps, "placement"> & {
   headerCloseBtn: boolean;
 };
 
-export const Default: StoryFn<DrawerArgs> = (args) => {
+export const Default: StoryFn<DrawerArgs> = (args: DrawerArgs) => {
   const { headerCloseBtn, ...rest } = args;
   const [isOpen, setIsOpen] = useState(false);
 
@@ -67,10 +67,9 @@ export const Default: StoryFn<DrawerArgs> = (args) => {
 
 Default.args = {
   placement: "left",
-  showMask: true,
 };
 
-export const MultipleDrawers: StoryFn<DrawerArgs> = (args) => {
+export const MultipleDrawers: StoryFn<DrawerArgs> = (args: DrawerArgs) => {
   const { headerCloseBtn, ...rest } = args;
   const [isFirstOpen, setIsFirstOpen] = useState(false);
   const [isSecondOpen, setIsSecondOpen] = useState(false);
@@ -128,5 +127,4 @@ export const MultipleDrawers: StoryFn<DrawerArgs> = (args) => {
 
 MultipleDrawers.args = {
   placement: "left",
-  showMask: true,
 };

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -42,6 +42,86 @@ describe("<Drawer/>", () => {
     expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
+  it("renders the visible mask when closeOnOutsideClick is false", () => {
+    render(
+      <Drawer isOpen closeOnOutsideClick={false} onClose={jest.fn()}>
+        <Drawer.Body>Drawer content</Drawer.Body>
+      </Drawer>,
+    );
+
+    expect(screen.getByTestId("mask")).toHaveAttribute("data-mask-visible", "true");
+  });
+
+  it("does not close on outside click when closeOnOutsideClick is false", async () => {
+    const mockFn = jest.fn();
+
+    render(
+      <Drawer isOpen closeOnOutsideClick={false} onClose={mockFn}>
+        <Drawer.Body>Drawer content</Drawer.Body>
+      </Drawer>,
+    );
+
+    await userEvent.click(screen.getByTestId("mask"));
+
+    expect(mockFn).not.toHaveBeenCalled();
+  });
+
+  it("renders only one visible mask when multiple drawers are open", () => {
+    render(
+      <>
+        <Drawer isOpen onClose={jest.fn()}>
+          <Drawer.Body>First drawer</Drawer.Body>
+        </Drawer>
+        <Drawer isOpen onClose={jest.fn()}>
+          <Drawer.Body>Second drawer</Drawer.Body>
+        </Drawer>
+      </>,
+    );
+
+    const masks = screen.getAllByTestId("mask");
+
+    expect(masks).toHaveLength(2);
+    expect(masks.filter((mask) => mask.getAttribute("data-mask-visible") === "true")).toHaveLength(
+      1,
+    );
+  });
+
+  it("promotes the visible mask when the top drawer closes", async () => {
+    const onCloseTop = jest.fn();
+
+    const { rerender } = render(
+      <>
+        <Drawer isOpen onClose={jest.fn()}>
+          <Drawer.Body>First drawer</Drawer.Body>
+        </Drawer>
+        <Drawer isOpen onClose={onCloseTop}>
+          <Drawer.Body>Second drawer</Drawer.Body>
+        </Drawer>
+      </>,
+    );
+
+    expect(
+      screen.getAllByTestId("mask").filter((mask) => mask.getAttribute("data-mask-visible") === "true"),
+    ).toHaveLength(1);
+
+    rerender(
+      <>
+        <Drawer isOpen onClose={jest.fn()}>
+          <Drawer.Body>First drawer</Drawer.Body>
+        </Drawer>
+        <Drawer isOpen={false} onClose={onCloseTop}>
+          <Drawer.Body>Second drawer</Drawer.Body>
+        </Drawer>
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId("mask").filter((mask) => mask.getAttribute("data-mask-visible") === "true"),
+      ).toHaveLength(1);
+    });
+  });
+
   it("renders correctly without Header and Footer", () => {
     const bodyTxt = faker.lorem.word();
     const mockFn = jest.fn();

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -101,7 +101,9 @@ describe("<Drawer/>", () => {
     );
 
     expect(
-      screen.getAllByTestId("mask").filter((mask) => mask.getAttribute("data-mask-visible") === "true"),
+      screen
+        .getAllByTestId("mask")
+        .filter((mask) => mask.getAttribute("data-mask-visible") === "true"),
     ).toHaveLength(1);
 
     rerender(
@@ -117,7 +119,9 @@ describe("<Drawer/>", () => {
 
     await waitFor(() => {
       expect(
-        screen.getAllByTestId("mask").filter((mask) => mask.getAttribute("data-mask-visible") === "true"),
+        screen
+          .getAllByTestId("mask")
+          .filter((mask) => mask.getAttribute("data-mask-visible") === "true"),
       ).toHaveLength(1);
     });
   });

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -49,7 +49,7 @@ describe("<Drawer/>", () => {
       </Drawer>,
     );
 
-    expect(screen.getByTestId("mask")).toHaveAttribute("data-mask-visible", "true");
+    expect(screen.getByTestId("mask")).toHaveAttribute("data-overlay", "true");
   });
 
   it("does not close on outside click when closeOnOutsideClick is false", async () => {
@@ -81,9 +81,7 @@ describe("<Drawer/>", () => {
     const masks = screen.getAllByTestId("mask");
 
     expect(masks).toHaveLength(2);
-    expect(masks.filter((mask) => mask.getAttribute("data-mask-visible") === "true")).toHaveLength(
-      1,
-    );
+    expect(masks.filter((mask) => mask.getAttribute("data-overlay") === "true")).toHaveLength(1);
   });
 
   it("promotes the visible mask when the top drawer closes", async () => {
@@ -101,9 +99,7 @@ describe("<Drawer/>", () => {
     );
 
     expect(
-      screen
-        .getAllByTestId("mask")
-        .filter((mask) => mask.getAttribute("data-mask-visible") === "true"),
+      screen.getAllByTestId("mask").filter((mask) => mask.getAttribute("data-overlay") === "true"),
     ).toHaveLength(1);
 
     rerender(
@@ -121,7 +117,7 @@ describe("<Drawer/>", () => {
       expect(
         screen
           .getAllByTestId("mask")
-          .filter((mask) => mask.getAttribute("data-mask-visible") === "true"),
+          .filter((mask) => mask.getAttribute("data-overlay") === "true"),
       ).toHaveLength(1);
     });
   });

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -16,6 +16,8 @@ import Header, { HeaderProps } from "./components/Header";
 import Body from "./components/Body";
 import Mask from "./components/Mask";
 import Footer from "./components/Footer";
+import { useDrawerStackPosition } from "./hooks/useDrawerStackPosition";
+import { DRAWER_ROOT_ID } from "./constants";
 import { FCWithChildren } from "types/common";
 
 type DialogVariants = {
@@ -40,14 +42,11 @@ const dialogVariants: Variants = {
   }),
 };
 
-const DRAWER_ROOT = "drawerRoot";
-
-const DrawerRoot: FCWithChildren = () => <div id={DRAWER_ROOT} />;
+const DrawerRoot: FCWithChildren = () => <div id={DRAWER_ROOT_ID} />;
 
 export type DrawerProps = React.HTMLAttributes<HTMLDivElement> & {
   isOpen: boolean;
   closeOnOutsideClick?: boolean;
-  showMask?: boolean;
   placement?: "left" | "right";
   width?: string;
   dialogStyles?: MotionStyle;
@@ -68,7 +67,6 @@ const Drawer: FCWithChildren<DrawerProps> & DrawerCompoundProps = (props) => {
     isOpen,
     placement = "left",
     closeOnOutsideClick = true,
-    showMask = true,
     width = "31.5rem",
     dialogStyles,
     dialogClassName,
@@ -88,7 +86,7 @@ const Drawer: FCWithChildren<DrawerProps> & DrawerCompoundProps = (props) => {
       })
     );
   });
-  const drawerEl = document.getElementById(DRAWER_ROOT);
+  const drawerEl = document.getElementById(DRAWER_ROOT_ID);
   const dialogClassNames = classNames({
     dialog: true,
     "placement-left": placement === "left",
@@ -96,12 +94,15 @@ const Drawer: FCWithChildren<DrawerProps> & DrawerCompoundProps = (props) => {
     [dialogClassName ?? ""]: dialogClassName,
   });
   const drawerRef = useRef<HTMLDivElement>(null);
+  const { isBottomMostOpenDrawer } = useDrawerStackPosition(isOpen);
 
-  const handleClose = () => {
-    if (!isOpen || !closeOnOutsideClick) return;
+  const handleOutsideClick = () => {
+    if (!isOpen) return;
 
     onClose();
   };
+  const shouldRenderMask = closeOnOutsideClick || isBottomMostOpenDrawer;
+  const shouldShowVisibleMask = isBottomMostOpenDrawer;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -155,7 +156,12 @@ const Drawer: FCWithChildren<DrawerProps> & DrawerCompoundProps = (props) => {
             ref={drawerRef}
             {...rest}
           >
-            {showMask && <Mask onClose={handleClose} />}
+            {shouldRenderMask && (
+              <Mask
+                visible={shouldShowVisibleMask}
+                onClick={closeOnOutsideClick ? handleOutsideClick : undefined}
+              />
+            )}
             <ReactFocusLock returnFocus disabled={!isOpen || disableFocusLock}>
               <m.dialog
                 id="drawer-dialog"

--- a/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -6,7 +6,8 @@ exports[`<Drawer/> matches snapshot with close button 1`] = `
   data-testid="drawer"
 >
   <div
-    class="css-tigpv4-maskContainer"
+    class="css-1h50gx7-maskContainer-maskContainer"
+    data-mask-visible="true"
     data-testid="mask"
     style="opacity: 0;"
   />
@@ -28,7 +29,7 @@ exports[`<Drawer/> matches snapshot with close button 1`] = `
       style="opacity: 0; transform: none;"
     >
       <div
-        class="drawer-header css-1ki9nyc-drawerHeader-drawerHeader"
+        class="drawer-header css-1bphbgo-drawerHeader-drawerHeader"
         data-testid="drawer-header"
         id="drawer-title"
       >
@@ -68,7 +69,8 @@ exports[`<Drawer/> matches snapshot with header, body and footer 1`] = `
   id="main-drawer"
 >
   <div
-    class="css-tigpv4-maskContainer"
+    class="css-1h50gx7-maskContainer-maskContainer"
+    data-mask-visible="true"
     data-testid="mask"
     style="opacity: 0;"
   />
@@ -90,7 +92,7 @@ exports[`<Drawer/> matches snapshot with header, body and footer 1`] = `
       style="opacity: 0; transform: none;"
     >
       <div
-        class="drawer-header css-1ki9nyc-drawerHeader-drawerHeader"
+        class="drawer-header css-1bphbgo-drawerHeader-drawerHeader"
         data-testid="drawer-header"
         id="drawer-title"
       >
@@ -119,7 +121,7 @@ exports[`<Drawer/> matches snapshot with header, body and footer 1`] = `
         Test body
       </div>
       <div
-        class="drawer-footer css-i1ukdc-footerContainer-footerContainer"
+        class="drawer-footer css-1pvwwi7-footerContainer-footerContainer"
         data-testid="drawer-footer"
       >
         Test footer
@@ -140,7 +142,8 @@ exports[`<Drawer/> matches snapshot with noGutters Header 1`] = `
   data-testid="drawer"
 >
   <div
-    class="css-tigpv4-maskContainer"
+    class="css-1h50gx7-maskContainer-maskContainer"
+    data-mask-visible="true"
     data-testid="mask"
     style="opacity: 0;"
   />
@@ -162,7 +165,7 @@ exports[`<Drawer/> matches snapshot with noGutters Header 1`] = `
       style="opacity: 0; transform: none;"
     >
       <div
-        class="drawer-header css-qa9tzz-drawerHeader-drawerHeader"
+        class="drawer-header css-1ni8vhz-drawerHeader-drawerHeader"
         data-testid="drawer-header"
         id="drawer-title"
       >
@@ -201,7 +204,8 @@ exports[`<Drawer/> matches snapshot with right placement 1`] = `
   data-testid="drawer"
 >
   <div
-    class="css-tigpv4-maskContainer"
+    class="css-1h50gx7-maskContainer-maskContainer"
+    data-mask-visible="true"
     data-testid="mask"
     style="opacity: 0;"
   />
@@ -223,7 +227,7 @@ exports[`<Drawer/> matches snapshot with right placement 1`] = `
       style="opacity: 0; transform: translateX(100%) translateZ(0);"
     >
       <div
-        class="drawer-header css-1ki9nyc-drawerHeader-drawerHeader"
+        class="drawer-header css-1bphbgo-drawerHeader-drawerHeader"
         data-testid="drawer-header"
         id="drawer-title"
       >
@@ -262,7 +266,8 @@ exports[`<Drawer/> matches snapshot without header and footer 1`] = `
   data-testid="drawer"
 >
   <div
-    class="css-tigpv4-maskContainer"
+    class="css-1h50gx7-maskContainer-maskContainer"
+    data-mask-visible="true"
     data-testid="mask"
     style="opacity: 0;"
   />

--- a/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<Drawer/> matches snapshot with close button 1`] = `
 >
   <div
     class="css-1h50gx7-maskContainer-maskContainer"
-    data-mask-visible="true"
+    data-overlay="true"
     data-testid="mask"
     style="opacity: 0;"
   />
@@ -70,7 +70,7 @@ exports[`<Drawer/> matches snapshot with header, body and footer 1`] = `
 >
   <div
     class="css-1h50gx7-maskContainer-maskContainer"
-    data-mask-visible="true"
+    data-overlay="true"
     data-testid="mask"
     style="opacity: 0;"
   />
@@ -143,7 +143,7 @@ exports[`<Drawer/> matches snapshot with noGutters Header 1`] = `
 >
   <div
     class="css-1h50gx7-maskContainer-maskContainer"
-    data-mask-visible="true"
+    data-overlay="true"
     data-testid="mask"
     style="opacity: 0;"
   />
@@ -205,7 +205,7 @@ exports[`<Drawer/> matches snapshot with right placement 1`] = `
 >
   <div
     class="css-1h50gx7-maskContainer-maskContainer"
-    data-mask-visible="true"
+    data-overlay="true"
     data-testid="mask"
     style="opacity: 0;"
   />
@@ -267,7 +267,7 @@ exports[`<Drawer/> matches snapshot without header and footer 1`] = `
 >
   <div
     class="css-1h50gx7-maskContainer-maskContainer"
-    data-mask-visible="true"
+    data-overlay="true"
     data-testid="mask"
     style="opacity: 0;"
   />

--- a/src/components/Drawer/components/Mask.tsx
+++ b/src/components/Drawer/components/Mask.tsx
@@ -12,18 +12,20 @@ const maskVariants: Variants = {
 };
 
 export type MaskProps = {
-  onClose: (e: MouseEvent) => void;
+  visible?: boolean;
+  onClick?: (e: MouseEvent) => void;
 };
 
-const Mask: FC<MaskProps> = ({ onClose }) => (
+const Mask: FC<MaskProps> = ({ visible = true, onClick }) => (
   <m.div
-    css={maskContainer}
-    onClick={onClose}
+    css={maskContainer(visible)}
+    onClick={onClick}
     initial="hidden"
     animate="expanded"
     exit="hidden"
     variants={maskVariants}
     data-testid="mask"
+    data-mask-visible={visible}
   />
 );
 

--- a/src/components/Drawer/components/Mask.tsx
+++ b/src/components/Drawer/components/Mask.tsx
@@ -25,7 +25,7 @@ const Mask: FC<MaskProps> = ({ visible = true, onClick }) => (
     exit="hidden"
     variants={maskVariants}
     data-testid="mask"
-    data-mask-visible={visible}
+    data-overlay={visible}
   />
 );
 

--- a/src/components/Drawer/components/styles.ts
+++ b/src/components/Drawer/components/styles.ts
@@ -26,14 +26,15 @@ export const drawerBody = css`
   overflow-y: auto;
 `;
 
-export const maskContainer = css`
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  background-color: rgba(0, 0, 0, 0.45);
-`;
+export const maskContainer = (visible: boolean): SerializedStyles =>
+  css`
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    background-color: ${visible ? "rgba(0, 0, 0, 0.45)" : "transparent"};
+  `;
 
 export const footerContainer = css`
   padding: 1rem;

--- a/src/components/Drawer/constants.ts
+++ b/src/components/Drawer/constants.ts
@@ -1,0 +1,1 @@
+export const DRAWER_ROOT_ID = "drawerRoot";

--- a/src/components/Drawer/hooks/useDrawerStackPosition.test.ts
+++ b/src/components/Drawer/hooks/useDrawerStackPosition.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from "@test-utils/render";
+import { useDrawerStackPosition } from "./useDrawerStackPosition";
+
+const mountDrawerStack = (initialProps: { isOpen: boolean }) => {
+  return renderHook(({ isOpen }) => useDrawerStackPosition(isOpen), { initialProps });
+};
+
+describe("useDrawerStackPosition", () => {
+  const mountedHooks: ReturnType<typeof mountDrawerStack>[] = [];
+
+  const resetMountedDrawers = (): void => {
+    mountedHooks.forEach(({ unmount }) => unmount());
+    mountedHooks.length = 0;
+  };
+
+  beforeEach(() => {
+    resetMountedDrawers();
+  });
+
+  afterEach(() => {
+    resetMountedDrawers();
+  });
+
+  const trackHook = (hook: ReturnType<typeof mountDrawerStack>) => {
+    mountedHooks.push(hook);
+
+    return hook;
+  };
+
+  it("returns false when the drawer is closed", () => {
+    const { result } = trackHook(mountDrawerStack({ isOpen: false }));
+
+    expect(result.current.isBottomMostOpenDrawer).toBe(false);
+  });
+
+  it("does not register a closed drawer in the stack", () => {
+    trackHook(mountDrawerStack({ isOpen: false }));
+    const { result } = trackHook(mountDrawerStack({ isOpen: true }));
+
+    expect(result.current.isBottomMostOpenDrawer).toBe(true);
+  });
+
+  it("returns true when a single drawer is open", () => {
+    const { result } = trackHook(mountDrawerStack({ isOpen: true }));
+
+    expect(result.current.isBottomMostOpenDrawer).toBe(true);
+  });
+
+  it("shows the visible mask only on the bottom-most drawer when nested", () => {
+    const parent = trackHook(mountDrawerStack({ isOpen: true }));
+    const child = trackHook(mountDrawerStack({ isOpen: true }));
+
+    expect(parent.result.current.isBottomMostOpenDrawer).toBe(true);
+    expect(child.result.current.isBottomMostOpenDrawer).toBe(false);
+  });
+
+  it("registers nested drawers in open order", () => {
+    const first = trackHook(mountDrawerStack({ isOpen: true }));
+    const second = trackHook(mountDrawerStack({ isOpen: true }));
+    const third = trackHook(mountDrawerStack({ isOpen: true }));
+
+    expect(first.result.current.isBottomMostOpenDrawer).toBe(true);
+    expect(second.result.current.isBottomMostOpenDrawer).toBe(false);
+    expect(third.result.current.isBottomMostOpenDrawer).toBe(false);
+  });
+
+  it("promotes the parent when the top nested drawer closes", () => {
+    const parent = trackHook(mountDrawerStack({ isOpen: true }));
+    const child = trackHook(mountDrawerStack({ isOpen: true }));
+
+    act(() => {
+      child.rerender({ isOpen: false });
+    });
+
+    expect(parent.result.current.isBottomMostOpenDrawer).toBe(true);
+    expect(child.result.current.isBottomMostOpenDrawer).toBe(false);
+  });
+
+  it("promotes the remaining drawer when the bottom drawer closes", () => {
+    const parent = trackHook(mountDrawerStack({ isOpen: true }));
+    const child = trackHook(mountDrawerStack({ isOpen: true }));
+
+    act(() => {
+      parent.rerender({ isOpen: false });
+    });
+
+    expect(parent.result.current.isBottomMostOpenDrawer).toBe(false);
+    expect(child.result.current.isBottomMostOpenDrawer).toBe(true);
+  });
+
+  it("removes the drawer from the stack on unmount while open", () => {
+    const parent = trackHook(mountDrawerStack({ isOpen: true }));
+    const child = trackHook(mountDrawerStack({ isOpen: true }));
+
+    act(() => {
+      child.unmount();
+      mountedHooks.pop();
+    });
+
+    expect(parent.result.current.isBottomMostOpenDrawer).toBe(true);
+  });
+});

--- a/src/components/Drawer/hooks/useDrawerStackPosition.test.ts
+++ b/src/components/Drawer/hooks/useDrawerStackPosition.test.ts
@@ -1,5 +1,5 @@
-import { act, renderHook } from "@test-utils/render";
 import { useDrawerStackPosition } from "./useDrawerStackPosition";
+import { act, renderHook } from "@test-utils/render";
 
 const mountDrawerStack = (initialProps: { isOpen: boolean }) => {
   return renderHook(({ isOpen }) => useDrawerStackPosition(isOpen), { initialProps });

--- a/src/components/Drawer/hooks/useDrawerStackPosition.ts
+++ b/src/components/Drawer/hooks/useDrawerStackPosition.ts
@@ -1,0 +1,48 @@
+import { useId, useLayoutEffect, useSyncExternalStore } from "react";
+
+let openDrawerStack: string[] = [];
+const listeners = new Set<() => void>();
+
+const subscribe = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+
+  return (): void => {
+    listeners.delete(listener);
+  };
+};
+
+const notifyDrawerStackListeners = (): void => {
+  listeners.forEach((listener) => listener());
+};
+
+const getIsBottomMostOpenDrawer = (key: string, isOpen: boolean): boolean => {
+  return isOpen && openDrawerStack[0] === key;
+};
+
+/**
+ * Tracks open drawers globally so only the bottom-most drawer renders the visible backdrop.
+ * Uses open order and `useSyncExternalStore` for tear-free reads.
+ */
+export const useDrawerStackPosition = (isOpen: boolean): { isBottomMostOpenDrawer: boolean } => {
+  const key = useId();
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    openDrawerStack.push(key);
+    notifyDrawerStackListeners();
+
+    return (): void => {
+      openDrawerStack = openDrawerStack.filter((stackKey) => stackKey !== key);
+      notifyDrawerStackListeners();
+    };
+  }, [isOpen, key]);
+
+  const isBottomMostOpenDrawer = useSyncExternalStore(
+    subscribe,
+    () => getIsBottomMostOpenDrawer(key, isOpen),
+    () => false,
+  );
+
+  return { isBottomMostOpenDrawer };
+};


### PR DESCRIPTION
## Problem

When multiple `<Drawer>` components are open simultaneously (e.g. opening a drawer from within another drawer), each instance independently renders its own semi-transparent backdrop mask. The masks stack on top of each other, causing the background to become progressively darker with each additional drawer. Navigating back and forth compounds the issue that the accumulated backdrop layers are never cleaned up, making the left side of the screen increasingly opaque.

## Changes

- **New `useDrawerStackPosition` hook:** Maintains a module-level `openDrawerStack` array tracking all open drawer instances by `useId()`. Uses `useSyncExternalStore` for tear-free reads and `useLayoutEffect` for synchronous registration/cleanup. Only the drawer at index `0` (the first opened) returns `isBottomMostOpenDrawer: true` — all subsequent drawers render a transparent mask instead.
- **Removed `showMask` prop from `DrawerProps`:** Mask visibility is now fully automatic based on stack position — consumers no longer need to pass `showMask`. The `Mask` component accepts `visible` (controls background opacity) and `onClick` (optional close handler) instead of the previous `onClose`.
- **Conditional mask rendering and click behaviour:** `shouldRenderMask = closeOnOutsideClick || isBottomMostOpenDrawer` ensures the mask element exists when needed for click interception or backdrop display. `shouldShowVisibleMask = isBottomMostOpenDrawer` controls whether the backdrop is opaque or transparent. When `closeOnOutsideClick` is `false`, the mask renders (visible if bottom-most) but doesn't fire the close callback.
- **`maskContainer` style converted to function:** Now accepts a `visible` boolean — renders `rgba(0, 0, 0, 0.45)` when visible, `transparent` otherwise. Added `data-mask-visible` attribute for test assertions.
- **Extracted `DRAWER_ROOT_ID` constant** from inline string to `constants.ts`.
- **102-line hook test suite** (`useDrawerStackPosition.test.ts`): Covers single drawer, nested drawers, 3-deep nesting, closing top/bottom drawer promotion, and unmount while open.
- **84 lines of new integration tests** in `Drawer.test.tsx`: Covers visible mask with `closeOnOutsideClick=false`, disabled outside click, single visible mask with multiple drawers, and mask promotion on close.

## Fixes

- Multiple backdrop overlays stacking when opening nested drawers — now only the bottom-most drawer shows the visible mask.
- Backdrop darkening on repeated back-and-forth navigation — stack cleanup happens synchronously on close/unmount.