### PR TITLE
fix(select): make clear indicator keyboard accessible

### DIFF
--- a/src/components/FormElements/Select/Select.test.tsx
+++ b/src/components/FormElements/Select/Select.test.tsx
@@ -4,6 +4,8 @@ import userEvent from "@testing-library/user-event";
 import Select from "./Select";
 import { render, fireEvent, screen } from "@test-utils/render";
 
+const CLEAR_INDICATOR_TESTID = "my-select-clear";
+
 const OPTIONS = [
   {
     label: faker.random.words(),
@@ -95,6 +97,26 @@ describe("<Select />", () => {
     expect(onChange).toHaveBeenCalledWith(null, expect.objectContaining({ action: "clear" }));
   });
 
+  it("keeps focus on the select's input after clearing with the keyboard", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Select
+        id="my-select"
+        label="Test select input"
+        options={OPTIONS}
+        isClearable
+        value={OPTIONS[0]}
+      />,
+    );
+
+    const clearIndicator = screen.getByTestId(CLEAR_INDICATOR_TESTID);
+    clearIndicator.focus();
+    await user.keyboard("{Enter}");
+
+    const selectInput = container.querySelector("input");
+    expect(selectInput).toHaveFocus();
+  });
+
   it("clears all selected values with the keyboard for a multi select", async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
@@ -110,7 +132,7 @@ describe("<Select />", () => {
       />,
     );
 
-    const clearIndicator = screen.getByRole("button", { name: /clear selection/i });
+    const clearIndicator = screen.getByTestId(CLEAR_INDICATOR_TESTID);
 
     clearIndicator.focus();
     await user.keyboard(" ");
@@ -130,11 +152,52 @@ describe("<Select />", () => {
       />,
     );
 
-    const clearIndicator = screen.getByRole("button", { name: /clear selection/i });
+    const clearIndicator = screen.getByTestId(CLEAR_INDICATOR_TESTID);
     clearIndicator.focus();
     await user.keyboard(" ");
 
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("does not reopen the menu when clearing a multi select with the keyboard", async () => {
+    const user = userEvent.setup();
+    render(
+      <Select
+        id="my-select"
+        label="Test select input"
+        options={OPTIONS}
+        isClearable
+        isMulti
+        value={[OPTIONS[0], OPTIONS[1]]}
+      />,
+    );
+
+    const clearIndicator = screen.getByTestId(CLEAR_INDICATOR_TESTID);
+    clearIndicator.focus();
+    await user.keyboard(" ");
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("keeps focus on the select's input after clearing a multi select with the keyboard", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Select
+        id="my-select"
+        label="Test select input"
+        options={OPTIONS}
+        isClearable
+        isMulti
+        value={[OPTIONS[0], OPTIONS[1]]}
+      />,
+    );
+
+    const clearIndicator = screen.getByTestId(CLEAR_INDICATOR_TESTID);
+    clearIndicator.focus();
+    await user.keyboard(" ");
+
+    const selectInput = container.querySelector("input");
+    expect(selectInput).toHaveFocus();
   });
 
   it("still clears the selected value on click", () => {
@@ -150,7 +213,7 @@ describe("<Select />", () => {
       />,
     );
 
-    const clearIndicator = screen.getByRole("button", { name: /clear selection/i });
+    const clearIndicator = screen.getByTestId(CLEAR_INDICATOR_TESTID);
     fireEvent.mouseDown(clearIndicator, { button: 0 });
 
     expect(onChange).toHaveBeenCalledWith(null, expect.objectContaining({ action: "clear" }));

--- a/src/components/FormElements/Select/Select.test.tsx
+++ b/src/components/FormElements/Select/Select.test.tsx
@@ -118,6 +118,25 @@ describe("<Select />", () => {
     expect(onChange).toHaveBeenCalledWith([], expect.objectContaining({ action: "clear" }));
   });
 
+  it("does not reopen the menu when clearing with the keyboard", async () => {
+    const user = userEvent.setup();
+    render(
+      <Select
+        id="my-select"
+        label="Test select input"
+        options={OPTIONS}
+        isClearable
+        value={OPTIONS[0]}
+      />,
+    );
+
+    const clearIndicator = screen.getByRole("button", { name: /clear selection/i });
+    clearIndicator.focus();
+    await user.keyboard(" ");
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
   it("still clears the selected value on click", () => {
     const onChange = jest.fn();
     render(

--- a/src/components/FormElements/Select/Select.test.tsx
+++ b/src/components/FormElements/Select/Select.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { faker } from "@faker-js/faker";
+import userEvent from "@testing-library/user-event";
 import Select from "./Select";
-import { render, fireEvent } from "@test-utils/render";
+import { render, fireEvent, screen } from "@test-utils/render";
 
 const OPTIONS = [
   {
@@ -69,5 +70,70 @@ describe("<Select />", () => {
     fireEvent.keyDown(selectInput as HTMLElement, { key: "ArrowDown", code: 40 });
 
     expect(container).toMatchSnapshot();
+  });
+
+  it("clears the selected value with the keyboard via the clear indicator", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(
+      <Select
+        id="my-select"
+        label="Test select input"
+        options={OPTIONS}
+        isClearable
+        onChange={onChange}
+        value={OPTIONS[0]}
+      />,
+    );
+
+    const clearIndicator = screen.getByRole("button", { name: /clear selection/i });
+    expect(clearIndicator).toHaveAttribute("tabIndex", "0");
+
+    clearIndicator.focus();
+    await user.keyboard("{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith(null, expect.objectContaining({ action: "clear" }));
+  });
+
+  it("clears all selected values with the keyboard for a multi select", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(
+      <Select
+        id="my-select"
+        label="Test select input"
+        options={OPTIONS}
+        isClearable
+        isMulti
+        onChange={onChange}
+        value={[OPTIONS[0], OPTIONS[1]]}
+      />,
+    );
+
+    const clearIndicator = screen.getByRole("button", { name: /clear selection/i });
+
+    clearIndicator.focus();
+    await user.keyboard(" ");
+
+    expect(onChange).toHaveBeenCalledWith([], expect.objectContaining({ action: "clear" }));
+  });
+
+  it("still clears the selected value on click", () => {
+    const onChange = jest.fn();
+    render(
+      <Select
+        id="my-select"
+        label="Test select input"
+        options={OPTIONS}
+        isClearable
+        onChange={onChange}
+        value={OPTIONS[0]}
+      />,
+    );
+
+    const clearIndicator = screen.getByRole("button", { name: /clear selection/i });
+    fireEvent.mouseDown(clearIndicator, { button: 0 });
+
+    expect(onChange).toHaveBeenCalledWith(null, expect.objectContaining({ action: "clear" }));
   });
 });

--- a/src/components/FormElements/Select/Select.tsx
+++ b/src/components/FormElements/Select/Select.tsx
@@ -1,6 +1,19 @@
-import React, { ForwardRefRenderFunction, forwardRef, isValidElement, useRef } from "react";
+import React, {
+  ForwardRefRenderFunction,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+} from "react";
 import classNames from "classnames";
-import { ActionMeta, MultiValue, SelectInstance, SingleValue } from "react-select";
+import {
+  ActionMeta,
+  ClearIndicatorProps,
+  MultiValue,
+  SelectInstance,
+  SingleValue,
+} from "react-select";
 import { SerializedStyles } from "@emotion/react";
 import { AddOperatorSVG, InfoCircledSVG } from "../../../icons";
 import Label from "../Label/Label";
@@ -47,9 +60,23 @@ const Select: ForwardRefRenderFunction<
 
   const hasLabel = Boolean(label);
   const containerRef = useRef<HTMLInputElement>(null);
+  const selectRef = useRef<SelectInstance<CustomOption> | null>(null);
   const labelClassname = classNames({
     required,
   });
+
+  useImperativeHandle<SelectInstance<CustomOption> | null, SelectInstance<CustomOption> | null>(
+    forwardedRef,
+    () => selectRef.current,
+    [],
+  );
+
+  const ClearIndicatorWithRef = useCallback(
+    (indicatorProps: ClearIndicatorProps<CustomOption>) => (
+      <CustomClearIndicator {...indicatorProps} selectRef={selectRef} />
+    ),
+    [],
+  );
 
   const countOptions = () => {
     // Count the number of options, including nested options if exists
@@ -89,7 +116,7 @@ const Select: ForwardRefRenderFunction<
     ...rest,
     id: id,
     "aria-label": rest["aria-label"],
-    ref: forwardedRef,
+    ref: selectRef,
     styles,
     isMulti,
     classNames: {
@@ -102,7 +129,7 @@ const Select: ForwardRefRenderFunction<
       Option: CustomOptionComponent,
       SingleValue: CustomSingleValue,
       MultiValueLabel: CustomMultiValueLabel,
-      ClearIndicator: CustomClearIndicator,
+      ClearIndicator: ClearIndicatorWithRef,
     },
     formatCreateLabel,
     isSearchable: isSelectSearchable(),

--- a/src/components/FormElements/Select/Select.tsx
+++ b/src/components/FormElements/Select/Select.tsx
@@ -12,6 +12,7 @@ import { containerClassNames, renderSelect } from "./helpers";
 import CustomMultiValueLabel from "./components/CustomMultiValueLabel";
 import CustomSingleValue from "./components/CustomSingleValue";
 import CustomOptionComponent from "./components/CustomOptionComponent";
+import CustomClearIndicator from "./components/CustomClearIndicator";
 
 const Select: ForwardRefRenderFunction<
   SelectInstance<CustomOption>,
@@ -101,6 +102,7 @@ const Select: ForwardRefRenderFunction<
       Option: CustomOptionComponent,
       SingleValue: CustomSingleValue,
       MultiValueLabel: CustomMultiValueLabel,
+      ClearIndicator: CustomClearIndicator,
     },
     formatCreateLabel,
     isSearchable: isSelectSearchable(),

--- a/src/components/FormElements/Select/components/CustomClearIndicator.tsx
+++ b/src/components/FormElements/Select/components/CustomClearIndicator.tsx
@@ -1,0 +1,35 @@
+import React, { FC, KeyboardEvent, memo } from "react";
+import { components, ClearIndicatorProps } from "react-select";
+import { CustomOption } from "../types";
+
+const CustomClearIndicator: FC<ClearIndicatorProps<CustomOption>> = (props) => {
+  const { innerProps, selectProps, clearValue } = props;
+  const { isDisabled } = selectProps;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (isDisabled) {
+      return;
+    }
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      clearValue();
+    }
+  };
+
+  return (
+    <components.ClearIndicator
+      {...props}
+      innerProps={{
+        ...innerProps,
+        role: "button",
+        tabIndex: isDisabled ? -1 : 0,
+        "aria-label": "Clear selection",
+        "aria-hidden": undefined,
+        onKeyDown: handleKeyDown,
+      }}
+    />
+  );
+};
+
+export default memo(CustomClearIndicator);

--- a/src/components/FormElements/Select/components/CustomClearIndicator.tsx
+++ b/src/components/FormElements/Select/components/CustomClearIndicator.tsx
@@ -13,6 +13,7 @@ const CustomClearIndicator: FC<ClearIndicatorProps<CustomOption>> = (props) => {
 
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
+      event.stopPropagation();
       clearValue();
     }
   };

--- a/src/components/FormElements/Select/components/CustomClearIndicator.tsx
+++ b/src/components/FormElements/Select/components/CustomClearIndicator.tsx
@@ -1,36 +1,36 @@
-import React, { FC, KeyboardEvent, memo } from "react";
-import { components, ClearIndicatorProps } from "react-select";
+import React, { FC, KeyboardEvent, RefObject, memo } from "react";
+import { components, ClearIndicatorProps, SelectInstance } from "react-select";
 import { CustomOption } from "../types";
 
-const CustomClearIndicator: FC<ClearIndicatorProps<CustomOption>> = (props) => {
+type CustomClearIndicatorProps = ClearIndicatorProps<CustomOption> & {
+  selectRef: RefObject<SelectInstance<CustomOption>>;
+};
+
+const CustomClearIndicator: FC<CustomClearIndicatorProps> = ({ selectRef, ...props }) => {
   const { innerProps, selectProps, clearValue } = props;
-  const { isDisabled } = selectProps;
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
-    if (isDisabled) {
-      return;
-    }
-
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       event.stopPropagation();
       clearValue();
+      // The clear indicator unmounts once the value is gone, taking focus with
+      // it. Refocus the select's own input so keyboard users can keep going.
+      selectRef.current?.focus();
     }
   };
 
-  return (
-    <components.ClearIndicator
-      {...props}
-      innerProps={{
-        ...innerProps,
-        role: "button",
-        tabIndex: isDisabled ? -1 : 0,
-        "aria-label": "Clear selection",
-        "aria-hidden": undefined,
-        onKeyDown: handleKeyDown,
-      }}
-    />
-  );
+  const clearIndicatorInnerProps = {
+    ...innerProps,
+    role: "button",
+    tabIndex: 0,
+    "aria-label": "Clear selection",
+    "aria-hidden": undefined,
+    "data-testid": `${selectProps.id}-clear`,
+    onKeyDown: handleKeyDown,
+  };
+
+  return <components.ClearIndicator {...props} innerProps={clearIndicatorInnerProps} />;
 };
 
 export default memo(CustomClearIndicator);


### PR DESCRIPTION
## Description

This PR fixes a keyboard-accessibility bug in the Select component's clear ("X") button. Previously the
  clear indicator was not focusable, had no keyboard handler, and was hidden from screen readers
  (aria-hidden="true") — only mouse clicks or Backspace could clear a selected value. This affected every
  consumer of Select across the app (40+ call sites), including the Categories select in Account & Settings
  referenced in this [ticket](https://app.asana.com/1/638247575366/project/1207921943967270/task/1211197375292764).

## Changes

  - Added src/components/FormElements/Select/components/CustomClearIndicator.tsx, which wraps react-select's
  default ClearIndicator and adds role="button", tabIndex, aria-label="Clear selection", removes
  aria-hidden, and handles Enter/Space to call clearValue().
  - Registered CustomClearIndicator in Select.tsx's existing components override map (alongside Option,
  SingleValue, MultiValueLabel), so the fix applies everywhere Select is used.
  - Added tests in Select.test.tsx covering keyboard clearing (single and multi-select) and a regression
  check that mouse-click clearing still works.
